### PR TITLE
fix deprecation error

### DIFF
--- a/islandora_group.module
+++ b/islandora_group.module
@@ -212,7 +212,7 @@ function islandora_group_batch_finished($success, $results, $operations) {
  * @return bool
  *   Returns a TRUE if the entity type has the field.
  */
-function entityTypeHasField($entity_type = 'node', $field_name) {
+function entityTypeHasField($entity_type, $field_name) {
   $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
 
   foreach($bundles as $bundle => $label) {


### PR DESCRIPTION
As of PHP 8.0, function signatures cannot have optional parameters before required parameters. 

This PR removes the optional part of the `$entity_type`, with no loss of functionality, since `$entity_type` would never take on its default value.