### PR TITLE
fixed crash

### DIFF
--- a/src/Form/ConfirmCollectionAccessTermsForm.php
+++ b/src/Form/ConfirmCollectionAccessTermsForm.php
@@ -31,6 +31,7 @@ class ConfirmCollectionAccessTermsForm extends ConfirmFormBase {
         // get children nodes
         $query = \Drupal::entityQuery('node')
             ->condition('status', 1)
+            ->accessCheck(TRUE)
             ->condition('field_member_of', $this->id);
         $childrenNIDs = $query->execute();
 

--- a/src/Form/NodeAccessControlForm.php
+++ b/src/Form/NodeAccessControlForm.php
@@ -174,6 +174,7 @@ class NodeAccessControlForm extends FormBase {
         if (entityTypeHasField("node", "field_part_of")) { 
             $query = \Drupal::entityQuery('node')
                 ->condition('status', 1)
+                ->accessCheck(TRUE)
                 ->condition('field_part_of', $node->id());
             $part_of_NIDs = $query->execute();
         }
@@ -186,6 +187,7 @@ class NodeAccessControlForm extends FormBase {
             $member_of_NIDs= [];
             $query = \Drupal::entityQuery('node')
                 ->condition('status', 1)
+                ->accessCheck(TRUE)
                 ->condition('field_member_of', $node->id());
             $member_of_NIDs = $query->execute();
 

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -734,6 +734,7 @@ class Utilities
     $group_ids = array();
     $ids = \Drupal::entityQuery('group_relationship')
       ->condition('entity_id', $nid)
+      ->accessCheck(TRUE)
       ->execute();
 
     $relations = \Drupal\group\Entity\GroupRelationship::loadMultiple($ids);
@@ -753,6 +754,7 @@ class Utilities
     $group_ids = array();
     $ids = \Drupal::entityQuery('group_relationship')
       ->condition('entity_id', $mid)
+      ->accessCheck(TRUE)
       ->execute();
 
     $relations = \Drupal\group\Entity\GroupRelationship::loadMultiple($ids);


### PR DESCRIPTION
On entity queries, access checking must now be explicitly mentioned, otherwise crash. https://www.drupal.org/node/3201242

This PR sets `accessChecking` to true on each query, which was the default behaviour.