### PR TITLE
Remove Group Permission module dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     },
     "require": {
         "drupal/group": "^3.1",
-        "drupal/groupmedia": "^4.0@alpha",
-        "drupal/group_permissions":"^2.0@alpha"
+        "drupal/groupmedia": "^4.0@alpha"
     },
     "authors": [
         {

--- a/islandora_group.info.yml
+++ b/islandora_group.info.yml
@@ -5,7 +5,6 @@ core_version_requirement: ^8.8 || ^9 || ^10
 dependencies:
   - group
   - groupmedia
-  - group_permissions
   - field_permissions
   - media
   - taxonomy


### PR DESCRIPTION
The [Group Permission](https://www.drupal.org/project/group_permissions) has ongoing issues with the new version 2.0 , and 3.0 of Group module , so we're removing it as dependency.

Related issues: 
* https://www.drupal.org/project/group_permissions/issues/3368882
* https://www.drupal.org/project/group_permissions/issues/3327680 