### PR TITLE
Add check to see if node loads to getGroupsByNode and log as warning …

### DIFF
--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -744,10 +744,19 @@ class Utilities
     }
 
     // if the above approach is not effective
-    if (count($group_ids) == 0) {
+    if (empty($group_ids)) {
       $node = \Drupal\node\Entity\Node::load($nid);
+
+      if (!$node instanceof \Drupal\Core\Entity\EntityInterface) {
+        \Drupal::logger('islandora_group')->warning('Could not load node entity for nid @nid during getGroupsByNode()', [
+          '@nid' => $nid,
+        ]);
+          return [];
+      }
+
       $storage = \Drupal::entityTypeManager()->getStorage('group_relationship');
       $relations = $storage->loadByEntity($node);
+
       foreach ($relations as $rel) {
         if ($rel->getEntity()->getEntityTypeId() == 'node') {
           $group_ids[] = $rel->getGroup()->label();


### PR DESCRIPTION
…if not.

We ran into an indexing indexing on our site with nodes and media that have been moved into groups or deleted, which then caused an issue with cron making it crash (see below). We applied this fix, and are good to go now. Might be of interest to y'all.

```
TypeError: Drupal\group\Entity\Storage\GroupRelationshipStorage::loadByEntity(): Argument #1 ($entity) must be of type Drupal\Core\Entity\EntityInterface, null given, called in /var/www/html/drupal/web/modules/contrib/islandora_group/src/Utilities.php on line 750 in Drupal\group\Entity\Storage\GroupRelationshipStorage->loadByEntity() (line 213 of /var/www/html/drupal/web/modules/contrib/group/src/Entity/Storage/GroupRelationshipStorage.php)

#0 /var/www/html/drupal/web/modules/contrib/islandora_group/src/Utilities.php(750): Drupal\group\Entity\Storage\GroupRelationshipStorage->loadByEntity()
#1 /var/www/html/drupal/web/modules/contrib/group_solr/src/Plugin/search_api/processor/AccessControl.php(91): Drupal\islandora_group\Utilities::getGroupsByNode()
#2 /var/www/html/drupal/web/modules/contrib/search_api/src/Item/Item.php(289): Drupal\group_solr\Plugin\search_api\processor\AccessControl->addFieldValues()
#3 /var/www/html/drupal/web/modules/contrib/search_api/src/Entity/Index.php(1026): Drupal\search_api\Item\Item->getFields()
#4 /var/www/html/drupal/web/modules/contrib/search_api/src/Entity/Index.php(974): Drupal\search_api\Entity\Index->indexSpecificItems()
#5 /var/www/html/drupal/web/modules/contrib/search_api/search_api.module(117): Drupal\search_api\Entity\Index->indexItems()
#6 /var/www/html/drupal/web/core/lib/Drupal/Core/Cron.php(337): search_api_cron()
#7 /var/www/html/drupal/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(395): Drupal\Core\Cron->Drupal\Core\{closure}()
#8 /var/www/html/drupal/web/core/lib/Drupal/Core/Cron.php(320): Drupal\Core\Extension\ModuleHandler->invokeAllWith()
#9 /var/www/html/drupal/web/core/lib/Drupal/Core/Cron.php(159): Drupal\Core\Cron->invokeCronHandlers()
#10 /var/www/html/drupal/web/core/lib/Drupal/Core/ProxyClass/Cron.php(75): Drupal\Core\Cron->run()
#11 /var/www/html/drupal/web/core/modules/system/src/CronController.php(51): Drupal\Core\ProxyClass\Cron->run()
#12 [internal function]: Drupal\system\CronController->runManually()
#13 /var/www/html/drupal/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array()
#14 /var/www/html/drupal/web/core/lib/Drupal/Core/Render/Renderer.php(638): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#15 /var/www/html/drupal/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(121): Drupal\Core\Render\Renderer->executeInRenderContext()
#16 /var/www/html/drupal/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext()
#17 /var/www/html/drupal/vendor/symfony/http-kernel/HttpKernel.php(181): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#18 /var/www/html/drupal/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#19 /var/www/html/drupal/web/core/lib/Drupal/Core/StackMiddleware/Session.php(53): Symfony\Component\HttpKernel\HttpKernel->handle()
#20 /var/www/html/drupal/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle()
#21 /var/www/html/drupal/web/core/lib/Drupal/Core/StackMiddleware/ContentLength.php(28): Drupal\Core\StackMiddleware\KernelPreHandle->handle()
#22 /var/www/html/drupal/web/core/modules/big_pipe/src/StackMiddleware/ContentLength.php(32): Drupal\Core\StackMiddleware\ContentLength->handle()
#23 /var/www/html/drupal/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(116): Drupal\big_pipe\StackMiddleware\ContentLength->handle()
#24 /var/www/html/drupal/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(90): Drupal\page_cache\StackMiddleware\PageCache->pass()
#25 /var/www/html/drupal/web/core/modules/ban/src/BanMiddleware.php(50): Drupal\page_cache\StackMiddleware\PageCache->handle()
#26 /var/www/html/drupal/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\ban\BanMiddleware->handle()
#27 /var/www/html/drupal/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle()
#28 /var/www/html/drupal/web/core/lib/Drupal/Core/StackMiddleware/AjaxPageState.php(36): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle()
#29 /var/www/html/drupal/web/core/lib/Drupal/Core/StackMiddleware/StackedHttpKernel.php(51): Drupal\Core\StackMiddleware\AjaxPageState->handle()
#30 /var/www/html/drupal/web/core/lib/Drupal/Core/DrupalKernel.php(741): Drupal\Core\StackMiddleware\StackedHttpKernel->handle()
#31 /var/www/html/drupal/web/index.php(19): Drupal\Core\DrupalKernel->handle()
#32 {main}
```