### PR TITLE
Drupal 11 compatibility.

### DIFF
--- a/islandora_group.info.yml
+++ b/islandora_group.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Group'
 type: module
 description: 'This module implement Access control for Islandora objects and related media using Group module'
-core_version_requirement: ^8.8 || ^9 || ^10
+core_version_requirement: ^8.8 || ^9 || ^10 || ^11
 dependencies:
   - group
   - groupmedia

--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -13,11 +13,18 @@ use Drupal\Tests\BrowserTestBase;
 class LoadTest extends BrowserTestBase {
 
   /**
+   * Default theme to use during the test.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
    * Modules to enable.
    *
    * @var array
    */
-  public static $modules = ['islandora_group'];
+  protected static $modules = ['islandora_group'];
 
   /**
    * A user with permission to administer site configuration.


### PR DESCRIPTION
Address the following from upgrade_stats:

```
Islandora Group, --
Scanned on Wed, 02/11/2026 - 20:46

FILE: web/modules/contrib/islandora_group/tests/src/Functional/LoadTest.php

STATUS         LINE                           MESSAGE
--------------------------------------------------------------------------------
Check manually 13   Drupal\Tests\BrowserTestBase::$defaultTheme is required. See
                    https://www.drupal.org/node/3083055, which includes
                    recommendations on which theme to use.
--------------------------------------------------------------------------------
Check manually 20   Property
                    Drupal\Tests\islandora_group\Functional\LoadTest::$modules
                    property must be protected.
--------------------------------------------------------------------------------

FILE: web/modules/contrib/islandora_group/islandora_group.info.yml

STATUS         LINE                           MESSAGE
--------------------------------------------------------------------------------
Check manually 4    Value of core_version_requirement: ^8.8 || ^9 || ^10 is not
                    compatible with the next major version of Drupal core. See
                    https://drupal.org/node/3070687.
--------------------------------------------------------------------------------
```