### PR TITLE
fix/linting-errors-and-phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require": {
         "drupal/group": "^3.1",
-        "drupal/groupmedia": "^4.0@alpha"
+        "drupal/groupmedia": "^4.0@alpha",
+        "drupal/field_permissions": "^1.2"
     },
     "authors": [
         {

--- a/islandora_group.module
+++ b/islandora_group.module
@@ -5,205 +5,198 @@
  * Contains islandora_group.module.
  */
 
-use Drupal\Core\Entity\EntityForm;
+// phpcs:disable Drupal.NamingConventions.ValidFunctionName
+
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\node\NodeInterface;
 use Drupal\group\Entity\GroupRelationship;
 use Drupal\media\MediaInterface;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\islandora_group\Utilities;
 use Drupal\Core\Entity\EntityInterface;
+
 /**
  * Implements hook_help().
  */
 function islandora_group_help($route_name, RouteMatchInterface $route_match) {
-    switch ($route_name) {
-        // Main module help for the islandora_group module.
-        case 'help.page.islandora_group':
-            $output = '';
-            $output .= '<h3>' . t('About') . '</h3>';
-            $output .= '<p>' . t('This module assist to manage access control for node and media with Group module') . '</p>';
-            return $output;
+  switch ($route_name) {
+    // Main module help for the islandora_group module.
+    case 'help.page.islandora_group':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('This module assist to manage access control for node and media with Group module') . '</p>';
+      return $output;
 
-        default:
-    }
+    default:
+  }
 }
 
 /**
  * Implements hook_theme().
  */
 function islandora_group_theme() {
-    return [
-        'islandora_group' => [
-            'render element' => 'children',
-        ],
-    ];
+  return [
+    'islandora_group' => [
+      'render element' => 'children',
+    ],
+  ];
 }
 
 /**
- * Implements hook_entity_insert
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
+ * Implements hook_entity_insert().
  */
 function islandora_group_entity_insert(EntityInterface $entity) {
-    Utilities::sync_associated_taxonomy_with_group($entity, "insert");
+  Utilities::sync_associated_taxonomy_with_group($entity, "insert");
 }
 
 /**
- * Implements hook_entity_update
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
+ * Implements hook_entity_update().
  */
 function islandora_group_entity_update(EntityInterface $entity) {
-    Utilities::sync_associated_taxonomy_with_group($entity, "update");
+  Utilities::sync_associated_taxonomy_with_group($entity, "update");
 }
 
 /**
- * Implements hook_entity_delete
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
+ * Implements hook_entity_delete().
  */
 function islandora_group_entity_delete(EntityInterface $entity) {
-    Utilities::sync_associated_taxonomy_with_group($entity, "delete");
+  Utilities::sync_associated_taxonomy_with_group($entity, "delete");
 }
 
 /**
- * Implements hook_form_alter
- * @param $form
- * @param $form_state
- * @param $form_id
- * @return void
+ * Implements hook_form_alter().
  */
 function islandora_group_form_alter(&$form, &$form_state, $form_id) {
-     if (str_starts_with($form_id, "group_content_group_content_type")  && str_ends_with($form_id, "_delete_form")) {
-        // when insert update
-        $form['actions']['submit']['#submit'][] = 'form_submit_delete_relation_untagging_entity_to_group';
-    }
-     else if (in_array($form_id, ['media_access_control_form', "islandora_object_access_control_form"])) {
-        $form['#attached']['library'] = array(
-            'islandora_group/datatables',
-        );
-    }
+  if (str_starts_with($form_id, "group_content_group_content_type")  && str_ends_with($form_id, "_delete_form")) {
+    // When insert update.
+    $form['actions']['submit']['#submit'][] = 'form_submit_delete_relation_untagging_entity_to_group';
+  }
+  elseif (in_array($form_id, ['media_access_control_form', "islandora_object_access_control_form"])) {
+    $form['#attached']['library'] = [
+      'islandora_group/datatables',
+    ];
+  }
 }
 
 /**
  * Implements hook_node_delete().
  */
 function islandora_group_node_delete(NodeInterface $node) {
-    // Remove content from all groups.
-    foreach (GroupRelationship::loadByEntity($node) as $group_content) {
-        $group_content->delete();
-    }
+  // Remove content from all groups.
+  foreach (GroupRelationship::loadByEntity($node) as $group_content) {
+    $group_content->delete();
+  }
 }
 
 /**
  * Implements hook_media_delete().
  */
 function islandora_group_media_delete(MediaInterface $media) {
-    foreach (GroupRelationship::loadByEntity($media) as $group_content) {
-        $group_content->delete();
-    }
+  foreach (GroupRelationship::loadByEntity($media) as $group_content) {
+    $group_content->delete();
+  }
 }
 
 /**
  * Implements hook_node_insert().
  */
 function islandora_group_node_insert(NodeInterface $node) {
-    Utilities::print_log("islandora_group_node_insert");
-    // add this node to group
-    if (!Utilities::isCalledFromGroupModule()) {
-        Utilities::adding_islandora_object_to_group($node);
-    }
+  Utilities::print_log("islandora_group_node_insert");
+  // Add this node to group.
+  if (!Utilities::isCalledFromGroupModule()) {
+    Utilities::adding_islandora_object_to_group($node);
+  }
 }
 
 /**
  * Implements hook_node_update().
  */
 function islandora_group_node_update(NodeInterface $node) {
-    Utilities::print_log("islandora_group_node_update");
-    if (!Utilities::isCalledFromGroupModule()) {
-        Utilities::adding_islandora_object_to_group($node);
+  Utilities::print_log("islandora_group_node_update");
+  if (!Utilities::isCalledFromGroupModule()) {
+    Utilities::adding_islandora_object_to_group($node);
 
-        // Tag media with selected terms only while bulk batch update
-        if (Utilities::isCalledFromBulkBatch()) {
-            // get access control field from config
-            $access_control_field = Utilities::getAccessControlFieldinNode($node);
+    // Tag media with selected terms only while bulk batch update.
+    if (Utilities::isCalledFromBulkBatch()) {
+      // Get access control field from config.
+      $access_control_field = Utilities::getAccessControlFieldinNode($node);
 
-            // make sure the selected access control field valid
-            if (empty($access_control_field) || !$node->hasField($access_control_field) ) {
-                return;
-            }
+      // Make sure the selected access control field valid.
+      if (empty($access_control_field) || !$node->hasField($access_control_field)) {
+        return;
+      }
 
-            $node_terms = $node->get($access_control_field)->referencedEntities();
-            $targets = [];
-            foreach ($node_terms as $term) {
-                $targets[] = ['target_id' => $term->id()];
-            }
-            $medias = [];
-            if (!empty(\Drupal::hasService('islandora.utils'))) {
-                $medias = \Drupal::service('islandora.utils')->getMedia($node);
-            }
-            $other_medias = Utilities::getMedia($node);
-            if (count($other_medias) > 0) {
-                $medias = array_merge($medias, $other_medias);
-            }
-            foreach ($medias as $media) {
-                Utilities::taggingFieldAccessTermMedia($media, $targets);
-            }
-        }
+      $node_terms = $node->get($access_control_field)->referencedEntities();
+      $targets = [];
+      foreach ($node_terms as $term) {
+        $targets[] = ['target_id' => $term->id()];
+      }
+      $medias = [];
+      if (!empty(\Drupal::hasService('islandora.utils'))) {
+        $medias = \Drupal::service('islandora.utils')->getMedia($node);
+      }
+      $other_medias = Utilities::getMedia($node);
+      if (count($other_medias) > 0) {
+        $medias = array_merge($medias, $other_medias);
+      }
+      foreach ($medias as $media) {
+        Utilities::taggingFieldAccessTermMedia($media, $targets);
+      }
     }
+  }
 }
 
 /**
  * Implements hook_media_insert().
  */
 function islandora_group_media_insert(MediaInterface $media) {
-    Utilities::print_log("islandora_group_media_insert");
-    // add this node to group
-    if (!Utilities::isCalledFromGroupModule()) {
-        Utilities::adding_media_only_into_group($media);
-    }
+  Utilities::print_log("islandora_group_media_insert");
+  // Add this node to group.
+  if (!Utilities::isCalledFromGroupModule()) {
+    Utilities::adding_media_only_into_group($media);
+  }
 }
 
 /**
  * Implements hook_media_update().
  */
 function islandora_group_media_update(MediaInterface $media) {
-    Utilities::print_log("islandora_group_media_update");
-    // add this node to group
-    if (!Utilities::isCalledFromGroupModule()) {
-        Utilities::adding_media_only_into_group($media);
-    }
+  Utilities::print_log("islandora_group_media_update");
+  // Add this node to group.
+  if (!Utilities::isCalledFromGroupModule()) {
+    Utilities::adding_media_only_into_group($media);
+  }
 }
 
 /**
  * Batch 'finished' callback used by both batch 1 and batch 2.
  */
 function islandora_group_batch_finished($success, $results, $operations) {
-    $messenger = \Drupal::messenger();
-    if ($success) {
-        // Here we could do something meaningful with the results.
-        // We just display the number of nodes we processed...
-        $messenger->addMessage(t('Access control applied successfully.', ['@total' => count($operations)]));
-    }
-    else {
-        // An error occurred.
-        // $operations contains the operations that remained unprocessed.
-        $error_operation = reset($operations);
-        $messenger->addMessage(
-            t('An error occurred while applying @operation with arguments : @args',
-                [
-                    '@operation' => $error_operation[0],
-                    '@args' => print_r($error_operation[0], TRUE),
-                ]
-            )
-        );
-    }
+  $messenger = \Drupal::messenger();
+  if ($success) {
+    // Here we could do something meaningful with the results.
+    // We just display the number of nodes we processed...
+    $messenger->addMessage(t('Access control applied successfully.', ['@total' => count($operations)]));
+  }
+  else {
+    // An error occurred.
+    // $operations contains the operations that remained unprocessed.
+    $error_operation = reset($operations);
+    $messenger->addMessage(
+          t('An error occurred while applying @operation with arguments : @args',
+              [
+                '@operation' => $error_operation[0],
+                '@args' => print_r($error_operation[0], TRUE),
+              ]
+          )
+      );
+  }
 }
 
 /**
  * Check if an entity type has a field.
- * https://www.drupal.org/forum/support/post-installation/2020-06-25/how-to-check-if-field-exists-for-entitytypemanager
+ *
+ * - https://www.drupal.org/forum/support/post-installation/2020-06-25/how-to-check-if-field-exists-for-entitytypemanager.
+ *
  * @param string $entity_type
  *   The entity type.
  * @param string $field_name
@@ -215,7 +208,7 @@ function islandora_group_batch_finished($success, $results, $operations) {
 function entityTypeHasField($entity_type, $field_name) {
   $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
 
-  foreach($bundles as $bundle => $label) {
+  foreach ($bundles as $bundle => $label) {
     $all_bundle_fields = \Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type, $bundle);
     if (isset($all_bundle_fields[$field_name])) {
       return TRUE;

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -1,5 +1,9 @@
 <?php
 
+// phpcs:disable DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+// phpcs:disable DrupalPractice.Objects.GlobalFunction.GlobalFunction
+// phpcs:disable Drupal.Semantics.FunctionT.NotLiteralString
+
 namespace Drupal\islandora_group\Form;
 
 use Drupal\islandora_group\Utilities;
@@ -7,180 +11,182 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Class ConfigForm.
+ * The ConfigForm class.
  */
 class ConfigForm extends ConfigFormBase {
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getEditableConfigNames() {
-        return [
-            Utilities::CONFIG_NAME,
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      Utilities::CONFIG_NAME,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'config_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(Utilities::CONFIG_NAME);
+
+    // Get list of existed groups.
+    $group_types = \Drupal::service('entity_type.manager')->getStorage('group_type')->loadMultiple();
+
+    // Get list existing taxonomy vocabulary.
+    $entity = \Drupal::entityTypeManager()->getStorage('taxonomy_vocabulary');
+    $query = $entity->getQuery();
+    $taxonomy_ids = $query->execute();
+
+    $form['group'] = [
+      '#type' => 'details',
+      '#title' => $this->t("Group Configuration"),
+      '#open' => TRUE,
+    ];
+    $form['group']['description'] = [
+      '#markup' => $this->t("<p>Select a Taxonomy Vocabulary to associate with a Group Type for: </p><ul><li>When a group of that Group Type is created, a term in that vocabulary with the same name as Group name</li></ul>"),
+    ];
+    $is_inital = FALSE;
+    foreach ($group_types as $group_type) {
+      if (!empty($config->get($group_type->id(), 0))) {
+        $is_inital = TRUE;
+      }
+      $form['group'][$group_type->id()] = [
+        '#type' => 'select',
+        '#name' => $group_type->id(),
+        // phpcs:ignore -- Concatenating translatable strings is not allowed.
+        '#title' => $this->t('For <i>' . $group_type->label() . "</i> group:"),
+        '#options' => $taxonomy_ids,
+        '#required' => TRUE,
+        '#default_value' => $config->get($group_type->id(), 0),
+      ];
+    }
+
+    if ($is_inital) {
+      $form['content-type'] = [
+        '#type' => 'details',
+        '#title' => $this->t("Access Control field - Node"),
+        '#open' => TRUE,
+        '#tree' => TRUE,
+      ];
+      $form['content-type']['description'] = [
+        '#markup' => $this->t("<p>Select the access control field to associate with a Group for: </p><ul><li>When a group of that Group Type is created, a term in that vocabulary with the same name as Group name</li></ul>"),
+      ];
+
+      /*
+       * Node
+       */
+      $node_types = \Drupal::entityTypeManager()
+        ->getStorage('node_type')
+        ->loadMultiple();
+
+      foreach ($node_types as $nt_name => $node_type) {
+        $fields_options = [];
+        $fields = \Drupal::service('entity_field.manager')->getFieldDefinitions('node', $nt_name);
+
+        foreach ($fields as $fname => $field) {
+          if ($field->getType() === "entity_reference"
+              && isset($field->getSettings()['handler_settings']['target_bundles'])) {
+            $targets = array_keys($field->getSettings()['handler_settings']['target_bundles']);
+            if (in_array($config->get($group_type->id(), 0), $targets)) {
+              $fields_options[$fname] = $fname;
+            }
+          }
+        }
+
+        $f = (!empty($config->get('node-type-access-fields'))) ? $config->get('node-type-access-fields') : '';
+        $form['content-type'][$nt_name]['access-control-field'] = [
+          '#type' => 'select',
+          '#title' => $this->t($node_type->label()),
+          '#options' => $fields_options,
+          "#empty_option" => t('- Select -'),
+          '#default_value' => (!empty($f[$nt_name])) ? $f[$nt_name] : '',
         ];
-    }
+      }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFormId() {
-        return 'config_form';
-    }
+      /*
+       * Media
+       */
+      $media_types = \Drupal::entityTypeManager()
+        ->getStorage('media_type')
+        ->loadMultiple();
+      $form['media'] = [
+        '#type' => 'details',
+        '#title' => $this->t("Access Control field - Media"),
+        '#open' => TRUE,
+        '#tree' => TRUE,
+      ];
+      $form['media']['description'] = [
+        '#markup' => $this->t("<p>Select the access control field to associate with a Group for: </p><ul><li>When a group of that Group Type is created, a term in that vocabulary with the same name as Group name</li></ul>"),
+      ];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(array $form, FormStateInterface $form_state) {
-        $config = $this->config(Utilities::CONFIG_NAME);
+      foreach ($media_types as $media_name => $meida_type) {
+        $fields_options = [];
+        $fields = \Drupal::service('entity_field.manager')->getFieldDefinitions('media', $media_name);
+        foreach ($fields as $fname => $field) {
+          if ($field->getType() === "entity_reference"
+              && isset($field->getSettings()['handler_settings']['target_bundles'])) {
+            $targets = array_keys($field->getSettings()['handler_settings']['target_bundles']);
+            if (in_array($config->get($group_type->id(), 0), $targets)) {
+              $fields_options[$fname] = $fname;
+            }
+          }
+        }
 
-        // get list of existed groups
-        $group_types = \Drupal::service('entity_type.manager')->getStorage('group_type')->loadMultiple();
-
-        // get list existing taxonomy vocabulary
-        $entity = \Drupal::entityTypeManager()->getStorage('taxonomy_vocabulary');
-        $query = $entity->getQuery();
-        $taxonomy_ids = $query->execute();
-
-        $form['group'] = [
-            '#type' => 'details',
-            '#title' => $this->t("Group Configuration"),
-            '#open' => TRUE,
+        $f = (!empty($config->get('media-type-access-fields'))) ? $config->get('media-type-access-fields') : '';
+        $form['media'][$media_name]['access-control-field'] = [
+          '#type' => 'select',
+          '#title' => $this->t($meida_type->label()),
+          '#options' => $fields_options,
+          "#empty_option" => t('- Select -'),
+          '#default_value' => (!empty($f[$media_name])) ? $f[$media_name] : '',
         ];
-        $form['group']['description'] = [
-            '#markup' => $this->t("<p>Select a Taxonomy Vocabulary to associate with a Group Type for: </p><ul><li>When a group of that Group Type is created, a term in that vocabulary with the same name as Group name</li></ul>"),
-        ];
-        $is_inital = false;
-        foreach ($group_types as $group_type) {
-            if (!empty($config->get($group_type->id(), 0))) {
-                $is_inital = true;
-            }
-            $form['group'][$group_type->id()] = [
-                '#type' => 'select',
-                '#name' => $group_type->id(),
-                '#title' => $this->t('For <i>' . $group_type->label() . "</i> group:"),
-                '#options' => $taxonomy_ids,
-                '#required' => true,
-                '#default_value' => $config->get($group_type->id(), 0)
-            ];
-        }
-
-        if ($is_inital) {
-            $form['content-type'] = [
-                '#type' => 'details',
-                '#title' => $this->t("Access Control field - Node"),
-                '#open' => TRUE,
-                '#tree' => TRUE
-            ];
-            $form['content-type']['description'] = [
-                '#markup' => $this->t("<p>Select the access control field to associate with a Group for: </p><ul><li>When a group of that Group Type is created, a term in that vocabulary with the same name as Group name</li></ul>"),
-            ];
-
-            /*
-             * Node
-             */
-            $node_types = \Drupal::entityTypeManager()
-                ->getStorage('node_type')
-                ->loadMultiple();
-
-            foreach ($node_types as $nt_name => $node_type) {
-                $fields_options = [];
-                $fields = \Drupal::service('entity_field.manager')->getFieldDefinitions('node', $nt_name);
-
-                foreach ($fields as $fname => $field) {
-                    if ($field->getType() === "entity_reference"
-                      && isset($field->getSettings()['handler_settings']['target_bundles'])) {
-                        $targets = array_keys($field->getSettings()['handler_settings']['target_bundles']);
-                        if (in_array($config->get($group_type->id(), 0), $targets))
-                            $fields_options[$fname] = $fname;
-                    }
-                }
-
-                $f = (!empty($config->get('node-type-access-fields'))) ? $config->get('node-type-access-fields'): '';
-                $form['content-type'][$nt_name]['access-control-field'] = [
-                    '#type' => 'select',
-                    '#title' => $this->t($node_type->label()),
-                    '#options' => $fields_options,
-                    "#empty_option"=>t('- Select -'),
-                    '#default_value' => (!empty($f[$nt_name])) ? $f[$nt_name] : ''
-                ];
-            }
-
-            /*
-             * Media
-             */
-            $media_types = \Drupal::entityTypeManager()
-                ->getStorage('media_type')
-                ->loadMultiple();
-            $form['media'] = [
-                '#type' => 'details',
-                '#title' => $this->t("Access Control field - Media"),
-                '#open' => TRUE,
-                '#tree' => TRUE
-            ];
-            $form['media']['description'] = [
-                '#markup' => $this->t("<p>Select the access control field to associate with a Group for: </p><ul><li>When a group of that Group Type is created, a term in that vocabulary with the same name as Group name</li></ul>"),
-            ];
-
-
-            foreach ($media_types as $media_name => $meida_type) {
-                $fields_options = [];
-                $fields = \Drupal::service('entity_field.manager')->getFieldDefinitions('media', $media_name);
-                foreach ($fields as $fname => $field) {
-                    if ($field->getType() === "entity_reference"
-                      && isset($field->getSettings()['handler_settings']['target_bundles'])) {
-                        $targets = array_keys($field->getSettings()['handler_settings']['target_bundles']);
-                        if (in_array($config->get($group_type->id(), 0), $targets))
-                            $fields_options[$fname] = $fname;
-                    }
-                }
-
-                $f = (!empty($config->get('media-type-access-fields'))) ? $config->get('media-type-access-fields'): '';
-                $form['media'][$media_name]['access-control-field'] = [
-                    '#type' => 'select',
-                    '#title' => $this->t($meida_type->label()),
-                    '#options' => $fields_options,
-                    "#empty_option"=>t('- Select -'),
-                    '#default_value' => (!empty($f[$media_name])) ? $f[$media_name] : ''
-                ];
-            }
-        }
-
-        return parent::buildForm($form, $form_state);
+      }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function submitForm(array &$form, FormStateInterface $form_state) {
-        $config = $this->configFactory->getEditable(Utilities::CONFIG_NAME);
+    return parent::buildForm($form, $form_state);
+  }
 
-        $groups = \Drupal::service('entity_type.manager')->getStorage('group_type')->loadMultiple();
-        foreach ($groups as $group) {
-            if ($form_state->getValues()[$group->id()] !== NULL) {
-                $config->set($group->id(), $form_state->getValues()[$group->id()])->save();
-            }
-        }
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->configFactory->getEditable(Utilities::CONFIG_NAME);
 
-        // for node
-        $field_access_control_config = [];
-        foreach ($form_state->getValues()['content-type'] as $type => $field_value) {
-            if (!empty($field_value['access-control-field'])) {
-                $field_access_control_config[$type] = $field_value['access-control-field'];
-            }
-
-        }
-        $config->set("node-type-access-fields", $field_access_control_config)->save();
-
-        // for media
-        $field_access_control_config = [];
-        foreach ($form_state->getValues()['media'] as $type => $field_value) {
-            if (!empty($field_value['access-control-field'])) {
-                $field_access_control_config[$type] = $field_value['access-control-field'];
-            }
-        }
-        $config->set("media-type-access-fields", $field_access_control_config)->save();
-
-        parent::submitForm($form, $form_state);
+    $groups = \Drupal::service('entity_type.manager')->getStorage('group_type')->loadMultiple();
+    foreach ($groups as $group) {
+      if ($form_state->getValues()[$group->id()] !== NULL) {
+        $config->set($group->id(), $form_state->getValues()[$group->id()])->save();
+      }
     }
+
+    // For node.
+    $field_access_control_config = [];
+    foreach ($form_state->getValues()['content-type'] as $type => $field_value) {
+      if (!empty($field_value['access-control-field'])) {
+        $field_access_control_config[$type] = $field_value['access-control-field'];
+      }
+
+    }
+    $config->set("node-type-access-fields", $field_access_control_config)->save();
+
+    // For media.
+    $field_access_control_config = [];
+    foreach ($form_state->getValues()['media'] as $type => $field_value) {
+      if (!empty($field_value['access-control-field'])) {
+        $field_access_control_config[$type] = $field_value['access-control-field'];
+      }
+    }
+    $config->set("media-type-access-fields", $field_access_control_config)->save();
+
+    parent::submitForm($form, $form_state);
+  }
 
 }

--- a/src/Form/ConfirmCollectionAccessTermsForm.php
+++ b/src/Form/ConfirmCollectionAccessTermsForm.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Drupal\islandora_group\Form;
 
+use Drupal\taxonomy\Entity\Term;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-use Drupal\Core\Entity\EntityForm;
 use Drupal\group\Entity\GroupRelationship;
 
 /**
@@ -12,172 +13,175 @@ use Drupal\group\Entity\GroupRelationship;
  */
 class ConfirmCollectionAccessTermsForm extends ConfirmFormBase {
 
-    /**
-     * ID of the item to delete.
-     *
-     * @var int
-     */
-    protected $id;
+  /**
+   * ID of the item to delete.
+   *
+   * @var int
+   */
+  protected $id;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(array $form, FormStateInterface $form_state, string $nid = NULL) {
-        $this->id = $nid;
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?string $nid = NULL) {
+    $this->id = $nid;
 
-        // get collection node
-        $collection = \Drupal::entityTypeManager()->getStorage('node')->load($this->id);
+    // Get collection node.
+    $collection = \Drupal::entityTypeManager()->getStorage('node')->load($this->id);
 
-        // get children nodes
-        $query = \Drupal::entityQuery('node')
-            ->condition('status', 1)
-            ->accessCheck(TRUE)
-            ->condition('field_member_of', $this->id);
-        $childrenNIDs = $query->execute();
+    // Get children nodes.
+    $query = \Drupal::entityQuery('node')
+      ->condition('status', 1)
+      ->accessCheck(TRUE)
+      ->condition('field_member_of', $this->id);
+    $childrenNIDs = $query->execute();
 
-        $options = [];
-        foreach ($childrenNIDs as $cnid) {
-            $childNode = \Drupal::entityTypeManager()->getStorage('node')->load($cnid);
-            $options[$cnid] = $childNode->getTitle() . '. <a href="/node/'.$childNode->id().'" target="_blank">Click here</a>';
-        }
+    $options = [];
+    foreach ($childrenNIDs as $cnid) {
+      $childNode = \Drupal::entityTypeManager()->getStorage('node')->load($cnid);
+      $options[$cnid] = $childNode->getTitle() . '. <a href="/node/' . $childNode->id() . '" target="_blank">Click here</a>';
+    }
 
-        // get access control field from config
-        $access_control_field = Utilities::getAccessControlFieldinNode($collection);
+    // Get access control field from config.
+    $access_control_field = Utilities::getAccessControlFieldinNode($collection);
 
-        // make sure the selected access control field valid
-        if (empty($access_control_field) || !$collection->hasField($access_control_field) ) {
-            return;
-        }
+    // Make sure the selected access control field valid.
+    if (empty($access_control_field) || !$collection->hasField($access_control_field)) {
+      return;
+    }
 
-        // Exit early if it has no assigned access terms
-        $access_terms = $collection->get($access_control_field)->referencedEntities();
+    // Exit early if it has no assigned access terms.
+    $access_terms = $collection->get($access_control_field)->referencedEntities();
 
-        $form['groups'] = [
-            '#type' => 'container'
-        ];
-        $form['collection'] = [
-            '#type' => 'hidden',
-            '#value' => $collection->id()
-        ];
+    $form['groups'] = [
+      '#type' => 'container',
+    ];
+    $form['collection'] = [
+      '#type' => 'hidden',
+      '#value' => $collection->id(),
+    ];
 
-        $form['groups']['#tree'] = true;
-        $i = 0;
-        foreach ($access_terms as $term) {
-            $form['groups'][$term->id()] = array(
-                '#type' => 'details',
-                '#title' => $this
-                    ->t("Group: " . $term->getName()),
-                '#open' => true
-            );
-            $form['groups'][$term->id()]['term-id'] = [
-                '#type' => 'hidden',
-                '#value' => $term->id(),
-            ];
+    $form['groups']['#tree'] = TRUE;
+    $i = 0;
+    foreach ($access_terms as $term) {
+      $form['groups'][$term->id()] = [
+        '#type' => 'details',
+        '#title' => $this
+          // phpcs:ignore
+          ->t("Group: " . $term->getName()),
+        '#open' => TRUE,
+      ];
+      $form['groups'][$term->id()]['term-id'] = [
+        '#type' => 'hidden',
+        '#value' => $term->id(),
+      ];
 
+      $defaults = [];
+      foreach ($childrenNIDs as $cnid) {
+        // Loop through all child nodes of this collection,
+        // Check each node has access_term matched with group.
+        $childNode = \Drupal::entityTypeManager()->getStorage('node')->load($cnid);
 
-            $defaults = [];
-            foreach ($childrenNIDs as $cnid) {
-                // loop through all child nodes of this collection check each node has access_term matched with group
-                $childNode = \Drupal::entityTypeManager()->getStorage('node')->load($cnid);
+        // Get access control field from config.
+        $access_control_field = Utilities::getAccessControlFieldinNode($childNode);
 
-                // get access control field from config
-                $access_control_field = Utilities::getAccessControlFieldinNode($childNode);
-
-                if (!empty($access_control_field) && count($childNode->get($access_control_field)->referencedEntities())> 0 ) {
-                    $childTerms = $childNode->get($access_control_field)->referencedEntities();
-                    foreach ($childTerms as $t) {
-                        if ($t->id() === $term->id()) {
-                            array_push($defaults, $childNode->id());
-                            break;
-                        }
-                    }
-                }
+        if (!empty($access_control_field) && count($childNode->get($access_control_field)->referencedEntities()) > 0) {
+          $childTerms = $childNode->get($access_control_field)->referencedEntities();
+          foreach ($childTerms as $t) {
+            if ($t->id() === $term->id()) {
+              array_push($defaults, $childNode->id());
+              break;
             }
-            $form['groups'][$term->id()]['select-nodes'] = array(
-                '#type' => 'checkboxes',
-                '#options' => $options,
-                '#title' => $this->t('Select the following nodes:'),
-                '#default_value' => $defaults,
-            );
-            $i++;
+          }
         }
-
-        return parent::buildForm($form, $form_state);
+      }
+      $form['groups'][$term->id()]['select-nodes'] = [
+        '#type' => 'checkboxes',
+        '#options' => $options,
+        '#title' => $this->t('Select the following nodes:'),
+        '#default_value' => $defaults,
+      ];
+      $i++;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function submitForm(array &$form, FormStateInterface $form_state) {
-        $collection = \Drupal::entityTypeManager()->getStorage('node')->load($form_state->getValues()['collection']);
+    return parent::buildForm($form, $form_state);
+  }
 
-        foreach($form_state->getValues()['groups'] as $values) {
-            $termid = $values['term-id'];
-            $term_name = \Drupal\taxonomy\Entity\Term::load($termid)->get('name')->value;
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $collection = \Drupal::entityTypeManager()->getStorage('node')->load($form_state->getValues()['collection']);
 
-            foreach (array_keys($values['select-nodes'])  as $nid) {
-                // get a children node of this collection
-                $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+    foreach ($form_state->getValues()['groups'] as $values) {
+      $termid = $values['term-id'];
+      $term_name = Term::load($termid)->get('name')->value;
 
-                // search group-node relations based on term_name
-                foreach (GroupRelationship::loadByEntity($collection) as $group_content) {
-                    $group = $group_content->getGroup();
-                    if ($group->label() === $term_name) {
+      foreach (array_keys($values['select-nodes']) as $nid) {
+        // Get a children node of this collection.
+        $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
 
-                        // tagging a node
-                        $this->taggingNodeWithTerm($node, $termid);
+        // Search group-node relations based on term_name.
+        foreach (GroupRelationship::loadByEntity($collection) as $group_content) {
+          $group = $group_content->getGroup();
+          if ($group->label() === $term_name) {
 
-                        // add a children node to a group
-                        add_entity_to_group($node);
-                    }
-                }
-            }
+            // Tagging a node.
+            $this->taggingNodeWithTerm($node, $termid);
+
+            // Add a children node to a group.
+            add_entity_to_group($node);
+          }
         }
+      }
+    }
+  }
+
+  /**
+   * Tag field_access_terms of child node with a term.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   * @param int $termid
+   *   The term ID.
+   *
+   * @return void
+   *   No return value.
+   */
+  public function taggingNodeWithTerm($node, $termid) {
+    // Get access control field from config.
+    $access_control_field = Utilities::getAccessControlFieldinNode($node);
+
+    if (empty($access_control_field) || !$node->hasField($access_control_field)) {
+      return;
     }
 
+    // Tag term to field_access_terms.
+    $node->get($access_control_field)->appendItem([
+      'target_id' => $termid,
+    ]);
+    $node->save();
+  }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() : string {
+    return "confirm_delete_form";
+  }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('node.add_page');
+  }
 
-    /**
-     * Tag field_access_terms of child node with a term
-     * @param $node
-     * @param $termid
-     * @return void
-     */
-    public function taggingNodeWithTerm($node, $termid) {
-        // get access control field from config
-        $access_control_field = Utilities::getAccessControlFieldinNode($node);
-
-        if (empty($access_control_field) || !$node->hasField($access_control_field)) {
-            return;
-        }
-
-        // tag term to field_access_terms
-        $node->get($access_control_field)->appendItem([
-            'target_id' => $termid,
-        ]);
-        $node->save();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFormId() : string {
-        return "confirm_delete_form";
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getCancelUrl() {
-        return new Url('node.add_page');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getQuestion() {
-        return $this->t("Adding children nodes of this Collection (ID: %id) to the following Groups:", ['%id' => $this->id]);
-    }
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t("Adding children nodes of this Collection (ID: %id) to the following Groups:", ['%id' => $this->id]);
+  }
 
 }

--- a/src/Form/MediaAccessControlForm.php
+++ b/src/Form/MediaAccessControlForm.php
@@ -1,140 +1,148 @@
 <?php
+
+// phpcs:disable Drupal.Commenting.DocComment.Empty
+// phpcs:disable DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+// phpcs:disable DrupalPractice.Objects.GlobalFunction.GlobalFunction
+// phpcs:disable Drupal.Semantics.FunctionT.Concat
+// phpcs:disable Drupal.Semantics.FunctionT.NotLiteralString
+// phpcs:disable DrupalPractice.Objects.GlobalClass.GlobalClass
+
 namespace Drupal\islandora_group\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\islandora_group\Utilities;
 use Drupal\media\MediaInterface;
-use Drupal\node\NodeInterface;
 use Drupal\media\Entity\Media;
 
+/**
+ *
+ */
 class MediaAccessControlForm extends FormBase {
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFormId() {
-        return 'media_access_control_form';
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'media_access_control_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?MediaInterface $media = NULL) {
+    // Get access control field from config.
+    $access_control_field = Utilities::getAccessControlFieldinMedia($media);
+
+    // Make sure the selected access control field valid.
+    if (empty($access_control_field) || !$media->hasField($access_control_field)) {
+      \Drupal::messenger()->addWarning(t('The media type <i>' . $media->bundle() . '</i> does not have an access control field. 
+                Please set the field for access control by <a href="/admin/config/access-control/islandora_group">clicking here</a>.'));
+      return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(array $form, FormStateInterface $form_state, MediaInterface $media = NULL) {
-        // get access control field from config
+    // Get the access terms for the node.
+    // Utilities::getIslandoraAccessTerms();
+    $group_terms = Utilities::getIslandoraAccessTermsinTable();
+    $node_term_default = [];
+
+    $node_terms = $media->get($access_control_field)->referencedEntities();
+    if (!empty($node_terms)) {
+      // No term, exist.
+      foreach ($node_terms as $nt) {
+        if (in_array($nt->id(), array_keys($group_terms))) {
+          $node_term_default[$nt->id()] = TRUE;
+        }
+        else {
+          $node_term_default[$nt->id()] = FALSE;
+        }
+      }
+    }
+
+    $form = [];
+    $form['#title'] = t($media->getName() . ' Media Access Control');
+    $form['#tree'] = TRUE;
+
+    $form['media_id'] = [
+      '#type' => 'hidden',
+      '#value' => $media->id(),
+    ];
+    $form['access-control'] = [
+      '#type' => 'container',
+    ];
+    $form['access-control']['media'] = [
+      '#type' => 'details',
+      '#title' => $this->t("Access control with Groups"),
+      '#open' => TRUE,
+    ];
+
+    $header = [
+      'group_id' => $this->t('Group ID'),
+      'group_name' => $this->t('Group Name'),
+      'group_permission' => $this->t('Permission'),
+      'group_member' => $this->t('Users'),
+    ];
+
+    $header = [
+      'group_name' => $this->t('Group'),
+      'group_permission' => $this->t('Group Permission'),
+      'group_member' => $this->t('Accounts can access'),
+    ];
+
+    $form['access-control']['media']['access-control'] = [
+      '#id' => 'group-media-table',
+      '#type' => 'tableselect',
+      '#attributes' => ['class' => ['stripe']],
+      '#header' => $header,
+      '#options' => $group_terms,
+      '#default_value' => $node_term_default,
+      '#empty' => $this->t('No users found'),
+      '#prefix' => $this->t('<p><h3>Select which group(s) to add this media to:</h3></p><div class="group-table">'),
+      '#suffix' => $this->t("</div>"),
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => 'Apply',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Selected group.
+    $selected_groups = array_values(array_filter($form_state->getValues()['access-control']['media']['access-control']));
+
+    // Media.
+    $media = Media::load($form_state->getValues()['media_id']);
+
+    // Untag field access terms in node level first.
+    Utilities::untag_existed_field_access_terms($media);
+
+    // Clear group relation with media.
+    Utilities::clear_group_relation_by_entity($media);
+
+    if (count($selected_groups) > 0) {
+      $targets = [];
+      foreach ($selected_groups as $term_id) {
+        $targets[] = ['target_id' => $term_id];
+      }
+      if (count($targets) > 0) {
+        // Get access control field from config.
         $access_control_field = Utilities::getAccessControlFieldinMedia($media);
 
-        // make sure the selected access control field valid
-        if (empty($access_control_field) || !$media->hasField($access_control_field) ) {
-            \Drupal::messenger()->addWarning(t('The media type <i>'.$media->bundle().'</i> does not have an access control field. 
-                Please set the field for access control by <a href="/admin/config/access-control/islandora_group">clicking here</a>.'));
-            return [];
+        if (!empty($access_control_field)) {
+          $media->set($access_control_field, $targets);
+          $media->save();
         }
-
-        // Get the access terms for the node.
-        $group_terms = Utilities::getIslandoraAccessTermsinTable();//Utilities::getIslandoraAccessTerms();
-        $node_term_default = [];
-
-        $node_terms = $media->get($access_control_field)->referencedEntities();
-        if (!empty($node_terms)) {
-            // no term, exist
-            foreach ($node_terms as $nt) {
-                if (in_array($nt->id(), array_keys($group_terms))) {
-                    $node_term_default[$nt->id()] = TRUE;
-                }
-                else {
-                    $node_term_default[$nt->id()] = FALSE;
-                }
-            }
-        }
-
-        $form = [];
-        $form['#title'] = t($media->getName() . ' Media Access Control');
-        $form['#tree'] = true;
-
-        $form['media_id'] = [
-            '#type' => 'hidden',
-            '#value' => $media->id()
-        ];
-        $form['access-control'] = [
-            '#type' => 'container'
-        ];
-        $form['access-control']['media'] = [
-            '#type' => 'details',
-            '#title' => $this->t("Access control with Groups"),
-            '#open' => TRUE,
-        ];
-
-        $header = [
-            'group_id' => $this->t('Group ID'),
-            'group_name' => $this->t('Group Name'),
-            'group_permission' => $this->t('Permission'),
-            'group_member' => $this->t('Users'),
-        ];
-
-        $header = [
-            'group_name' => $this->t('Group'),
-            'group_permission' => $this->t('Group Permission'),
-            'group_member' => $this->t('Accounts can access'),
-        ];
-
-        $form['access-control']['media']['access-control'] = array(
-            '#id' => 'group-media-table',
-            '#type' => 'tableselect',
-            '#attributes' => array('class' => array('stripe')),
-            '#header' => $header,
-            '#options' => $group_terms,
-            '#default_value' => $node_term_default,
-            '#empty' => $this->t('No users found'),
-            '#prefix' => $this->t('<p><h3>Select which group(s) to add this media to:</h3></p><div class="group-table">'),
-            '#suffix' => $this->t("</div>")
-        );
-
-        $form['submit'] = array(
-            '#type' => 'submit',
-            '#value' => 'Apply',
-        );
-
-        return $form;
+      }
+      // Add media to selected group.
+      Utilities::adding_media_only_into_group($media);
     }
 
-
-    /**
-     * {@inheritdoc}
-     */
-    public function submitForm(array &$form, FormStateInterface $form_state)
-    {
-        // selected group
-        $selected_groups = array_values(array_filter($form_state->getValues()['access-control']['media']['access-control']));
-
-        // media
-        $media = Media::load($form_state->getValues()['media_id']);
-
-        // untag field access terms in node level first
-        Utilities::untag_existed_field_access_terms($media);
-
-        // clear group relation with media
-        Utilities::clear_group_relation_by_entity($media);
-
-        if (count($selected_groups) > 0) {
-            $targets = [];
-            foreach ($selected_groups as $term_id) {
-                $targets[] = ['target_id' => $term_id];
-            }
-            if (count($targets) > 0) {
-                // get access control field from config
-                $access_control_field = Utilities::getAccessControlFieldinMedia($media);
-
-                if (!empty($access_control_field)) {
-                    $media->set($access_control_field, $targets);
-                    $media->save();
-                }
-            }
-            // add media to selected group
-            Utilities::adding_media_only_into_group($media);
-        }
-
-
-    }
+  }
 
 }

--- a/src/Form/NodeAccessControlForm.php
+++ b/src/Form/NodeAccessControlForm.php
@@ -1,4 +1,18 @@
 <?php
+
+// phpcs:disable Drupal.Commenting.DocComment.Empty
+// @todo Re-enable after fixing the errors and after refactoring.
+// phpcs:disable DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+// phpcs:disable DrupalPractice.Objects.GlobalFunction.GlobalFunction
+// phpcs:disable Drupal.Semantics.FunctionT.Concat
+// phpcs:disable Drupal.Files.LineLength.TooLong
+// phpcs:disable Drupal.Semantics.FunctionT.NotLiteralString
+// phpcs:disable Drupal.Semantics.FunctionT.WhiteSpace
+// phpcs:disable DrupalPractice.CodeAnalysis.VariableAnalysis.UnusedVariable
+// phpcs:disable Drupal.Arrays.Array.LongLineDeclaration
+// phpcs:disable DrupalPractice.Objects.GlobalClass.GlobalClass
+// phpcs:disable Drupal.Commenting.FileComment.NamespaceNoFileDoc
+
 namespace Drupal\islandora_group\Form;
 
 use Drupal\Core\Form\FormBase;
@@ -8,379 +22,377 @@ use Drupal\node\NodeInterface;
 use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
 
+/**
+ *
+ */
 class NodeAccessControlForm extends FormBase {
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFormId() {
-        return 'islandora_object_access_control_form';
-    }
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'islandora_object_access_control_form';
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(array $form, FormStateInterface $form_state, NodeInterface $node = NULL) {
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $node = NULL) {
 
-        // get access control field from config
-        $access_control_field = Utilities::getAccessControlFieldinNode($node);
+    // Get access control field from config.
+    $access_control_field = Utilities::getAccessControlFieldinNode($node);
 
-        // make sure the selected access control field valid
-        if (empty($access_control_field) || !$node->hasField($access_control_field) ) {
-            \Drupal::messenger()->addWarning(t('The content type - <i>'.$node->bundle().'</i> does not have an access control field. 
+    // Make sure the selected access control field valid.
+    if (empty($access_control_field) || !$node->hasField($access_control_field)) {
+      \Drupal::messenger()->addWarning(t('The content type - <i>' . $node->bundle() . '</i> does not have an access control field. 
                 Please set the field for access control by <a href="/admin/config/access-control/islandora_group">clicking here</a>.'));
-            return [];
+      return [];
+    }
+
+    // Get the access terms for the node.
+    $options_available_media = [];
+    $options_unvailable_media = [];
+
+    $medias = [];
+    if (!empty(\Drupal::hasService('islandora.utils'))) {
+      $medias = \Drupal::service('islandora.utils')->getMedia($node);
+    }
+    $other_medias = Utilities::getMedia($node);
+    if (count($other_medias) > 0) {
+      $medias = array_merge($medias, $other_medias);
+    }
+    foreach ($medias as $media) {
+      $groups = implode(", ", Utilities::getGroupsByMedia($media->id()));
+      // Get access control field from config.
+      if (isset($media)) {
+        $access_control_field = Utilities::getAccessControlFieldinMedia($media);
+        if (isset($access_control_field)) {
+          $terms = $media->get($access_control_field)->referencedEntities();
+          if (count($terms) > 0) {
+            // $options_unvailable_media[$media->id()] = $media->getName() . "  <a href='/media/".$media->id()."/access-control' target='_blank'>Configure seperately</a>";
+            $options_unvailable_media[$media->id()] = [
+              'media_title' => $this->t('<a href="/media/' . $media->id() . '" target="_blank">' . $media->getName() . '</a>'),
+              'groups' => $groups,
+              'media_permission' => $this->t('<a href="/media/' . $media->id() . '/access-control" target="_blank">Configuration</a>'),
+            ];
+          }
+          else {
+            // $options_available_media[$media->id()] = $media->getName() . "  <a href='/media/".$media->id()."/access-control' target='_blank'>Configure seperately</a>";
+            $options_available_media[$media->id()] = [
+              'media_title' => $this->t('<a href="/media/' . $media->id() . '" target="_blank">' . $media->getName() . '</a>'),
+              'groups' => $groups,
+              'media_permission' => $this->t('<a href="/media/' . $media->id() . '/access-control" target="_blank">Configuration</a>'),
+            ];
+          }
         }
+      }
 
-        // Get the access terms for the node.
-        $options_available_media = [];
-        $options_unvailable_media = [];
+    }
 
-        $medias = [];
+    $access_control_field = Utilities::getAccessControlFieldinNode($node);
+    // Utilities::getIslandoraAccessTerms();
+    $group_terms = Utilities::getIslandoraAccessTermsinTable();
+    $node_term_default = [];
+
+    $node_terms = $node->get($access_control_field)->referencedEntities();
+    if (!empty($node_terms)) {
+      // No term, exist.
+      foreach ($node_terms as $nt) {
+        if (in_array($nt->id(), array_keys($group_terms))) {
+          $node_term_default[$nt->id()] = TRUE;
+        }
+        else {
+          $node_term_default[$nt->id()] = FALSE;
+        }
+      }
+    }
+    $form = [];
+    $form['#title'] = t($node->getTitle() . ' Repository Item Access Control');
+    $form['#tree'] = TRUE;
+
+    $form['nid'] = [
+      '#type' => 'hidden',
+      '#value' => $node->id(),
+    ];
+    $form['access-control'] = [
+      '#type' => 'container',
+    ];
+    $form['access-control']['node'] = [
+      '#type' => 'details',
+      '#title' => $this->t($node->getTitle()),
+      '#open' => TRUE,
+    ];
+
+    $header = [
+      'group_name' => $this->t('Group'),
+      'group_permission' => $this->t('Group Permission'),
+      'group_member' => $this->t('Accounts can access'),
+    ];
+
+    $form['access-control']['node']['access-control'] = [
+      '#id' => 'group-node-table',
+      '#attributes' => ['class' => ['stripe']],
+      '#type' => 'tableselect',
+      '#header' => $header,
+      '#options' => $group_terms,
+      '#default_value' => $node_term_default,
+      '#empty' => $this->t('No users found'),
+      '#prefix' => $this->t('<p><h3>Select which group(s) to add this node to:</h3></p><div class="group-table">'),
+      '#suffix' => $this->t("</div>"),
+    ];
+
+    $form['access-control']['media'] = [
+      '#type' => 'details',
+      '#title' => $this->t("Media"),
+      '#open' => TRUE,
+    ];
+
+    $header = [
+      'media_title' => $this->t('Media'),
+      'groups' => $this->t("In Group(s)"),
+      'media_permission' => $this->t('Access Control'),
+    ];
+    if (count($options_available_media) > 0) {
+      $form['access-control']['media']['access-control'] = [
+        '#id' => 'group-media-has-access-control-table',
+        '#attributes' => ['class' => ['stripe']],
+        '#type' => 'tableselect',
+        '#title' => $this->t('Select media to add to the above group(s)'),
+        '#options' => $options_available_media,
+        '#header' => $header,
+        '#prefix' => $this->t('<p><h3>Select media to add to the above group(s):</h3></p>
+                                <div class="group-table">'),
+        '#suffix' => $this->t("</div>"),
+      ];
+    }
+
+    if (count($options_unvailable_media) > 0) {
+      $form['access-control']['media']['not-access-control'] = [
+        '#id' => 'group-media-has-no-access-control-table',
+        '#attributes' => ['class' => ['stripe']],
+        '#type' => 'table',
+        '#title' => $this->t('The following media already has access control: '),
+        '#rows' => $options_unvailable_media,
+        '#default_value' => array_keys($options_unvailable_media),
+        '#disabled' => TRUE,
+        '#header' => $header,
+        '#prefix' => $this->t('<p><h3>The following already have access control, please review before override them:</h3></p>
+                                <div class="group-table">'),
+        '#suffix' => $this->t("</div>"),
+      ];
+      $form['access-control']['media']['<strong>Override</strong>'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('<strong>Override</strong>'),
+        '#description' => $this->t("To have the same access control with this node"),
+      ];
+    }
+
+    // Get children nodes by field_part_of.
+    $part_of_NIDs = [];
+    if (entityTypeHasField("node", "field_part_of")) {
+      $query = \Drupal::entityQuery('node')
+        ->condition('status', 1)
+        ->accessCheck(TRUE)
+        ->condition('field_part_of', $node->id());
+      $part_of_NIDs = $query->execute();
+    }
+
+    if (Utilities::isCollection($node) || count($part_of_NIDs) > 0) {
+      // Check if this node is collection, redirect to confirm form
+      // get children nodes
+      // get children nodes by field_member_of.
+      $member_of_NIDs = [];
+      $query = \Drupal::entityQuery('node')
+        ->condition('status', 1)
+        ->accessCheck(TRUE)
+        ->condition('field_member_of', $node->id());
+      $member_of_NIDs = $query->execute();
+
+      // Merged them
+      // $childrenNids = array_merge($member_of_NIDs, $part_of_NIDs);.
+      $childrenNids = array_merge($member_of_NIDs, $part_of_NIDs);
+
+      $options_available_children = [];
+      $options_unvailable_children = [];
+
+      $options = [];
+
+      foreach ($childrenNids as $cnid) {
+        $childNode = \Drupal::entityTypeManager()->getStorage('node')->load($cnid);
+
+        // Get access control field from config.
+        $access_control_field = Utilities::getAccessControlFieldinNode($childNode);
+
+        $groups = implode(", ", Utilities::getGroupsByNode($cnid));
+        $childnode_terms = $childNode->get($access_control_field)->referencedEntities();
+        if (count($childnode_terms) > 0) {
+          // $options_unvailable_children[$cnid] = $childNode->getTitle() . '. <a href="/node/'.$childNode->id().'/access-control" target="_blank">Configure seperately</a>';
+          $options_unvailable_children[$cnid] = [
+            'node_title' => $this->t('<a href="/node/' . $childNode->id() . '" target="_blank">' . $childNode->getTitle() . '</a>'),
+            'groups' => $groups,
+            'node_permission' => $this->t('<a href="/node/' . $childNode->id() . '/access-control" target="_blank">Configuration</a>'),
+          ];
+        }
+        else {
+          // $options_available_children[$cnid] = $childNode->getTitle() . '. <a href="/node/'.$childNode->id().'/access-control" target="_blank">Configure seperately</a>';
+          $options_available_children[$cnid] = [
+            'node_title' => $this->t('<a href="/node/' . $childNode->id() . '" target="_blank">' . $childNode->getTitle() . '</a>'),
+            'groups' => $groups,
+            'node_permission' => $this->t('<a href="/node/' . $childNode->id() . '/access-control" target="_blank">Configuration</a>'),
+          ];
+        }
+      }
+      $form['access-control']['children-nodes'] = [
+        '#type' => 'details',
+        '#title' => $this->t("Children Nodes"),
+        '#open' => TRUE,
+      ];
+
+      $header = [
+        'node_title' => $this->t('Children Nodes'),
+        "groups" => $this->t("In Group(s)"),
+        'node_permission' => $this->t('Access Control'),
+      ];
+      if (count($options_available_children) > 0) {
+        $form['access-control']['children-nodes']['access-control'] = [
+          '#id' => 'group-children-nodes-has-no-access-control-table',
+          '#attributes' => ['class' => ['stripe']],
+          '#type' => 'tableselect',
+          '#header' => $header,
+          '#options' => $options_available_children,
+          '#prefix' => $this->t('<p><h3>Select the following children nodes:</h3></p>
+                                <div class="group-table">'),
+          '#suffix' => $this->t("</div>"),
+        ];
+      }
+      if (count($options_unvailable_children) > 0) {
+        $form['access-control']['children-nodes']['not-access-control'] = [
+          '#id' => 'group-children-nodes-has-access-control-table',
+          '#attributes' => ['class' => ['stripe']],
+          '#type' => 'table',
+          '#header' => $header,
+          '#rows' => $options_unvailable_children,
+          '#prefix' => $this->t('<p><h3>The following already have access control, please review before override them:</h3></p>
+                                <div class="group-table">'),
+          '#suffix' => $this->t("</div>"),
+          '#default_value' => array_keys($options_unvailable_children),
+          '#disabled' => TRUE,
+        ];
+        $form['access-control']['children-nodes']['<strong>Override</strong>'] = [
+          '#type' => 'checkbox',
+          '#title' => $this->t('<strong>Override</strong>'),
+          '#description' => $this->t("To have the same access control with this node"),
+        ];
+      }
+    }
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => 'Apply',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Get selected group.
+    $selected_groups = array_values(array_filter($form_state->getValues()['access-control']['node']['access-control']));
+
+    // Set selected term id.
+    $targets = [];
+    foreach ($selected_groups as $term_id) {
+      $targets[] = ['target_id' => $term_id];
+    }
+
+    // Tagging the parent node level.
+    $operations = [
+          ['\Drupal\islandora_group\Utilities::taggingFieldAccessTermsNode', [$form_state->getValues()['nid'], $targets]],
+    ];
+
+    // Get selected media.
+    if (isset($form_state->getValues()['access-control']['media']['access-control'])) {
+      $selected_media = array_values(array_filter($form_state->getValues()['access-control']['media']['access-control']));
+      foreach ($selected_media as $media_id) {
+        $media = Media::load($media_id);
+
+        // Tag the selected media of the node.
+        $operations[] = ['\Drupal\islandora_group\Utilities::taggingFieldAccessTermMedia', [$media, $targets]];
+      }
+    }
+
+    // Handle override.
+    if (isset($form_state->getValues()['access-control']['media']['<strong>Override</strong>']) && $form_state->getValues()['access-control']['media']['<strong>Override</strong>'] == TRUE) {
+      // Override the access control for already set media.
+      $override_media = array_values(array_filter($form_state->getValues()['access-control']['media']['not-access-control']));
+      foreach ($override_media as $omid) {
+        $media = Media::load($omid);
+        // Tag the override media.
+        $operations[] = ['\Drupal\islandora_group\Utilities::taggingFieldAccessTermMedia', [$media, $targets]];
+      }
+    }
+
+    // For children node.
+    if (isset($form_state->getValues()['access-control']['children-nodes']['access-control'])) {
+      $children_nodes = array_values(array_filter($form_state->getValues()['access-control']['children-nodes']['access-control']));
+      foreach ($children_nodes as $cnid) {
+        // Get selected child node.
+        $child = Node::load($cnid);
+
+        // Tagging the child node.
+        $operations[] = ['\Drupal\islandora_group\Utilities::taggingFieldAccessTermsNode', [$cnid, $targets]];
+
+        // @todo UI configure add child's media to group
+        $child_medias = [];
         if (!empty(\Drupal::hasService('islandora.utils'))) {
-            $medias = \Drupal::service('islandora.utils')->getMedia($node);
+          $child_medias = \Drupal::service('islandora.utils')->getMedia($child);
         }
-        $other_medias = Utilities::getMedia($node);
+        $other_medias = Utilities::getMedia($child);
         if (count($other_medias) > 0) {
-            $medias = array_merge($medias, $other_medias);
-        }
-        foreach ($medias as $media) {
-              $groups = implode(", ", Utilities::getGroupsByMedia($media->id()));
-            // get access control field from config
-            if (isset($media)) {
-                $access_control_field = Utilities::getAccessControlFieldinMedia($media);
-                if (isset($access_control_field)) {
-                    $terms = $media->get($access_control_field)->referencedEntities();
-                    if (count($terms) > 0) {
-                        //$options_unvailable_media[$media->id()] = $media->getName() . "  <a href='/media/".$media->id()."/access-control' target='_blank'>Configure seperately</a>";
-                        $options_unvailable_media[$media->id()] = [
-                            'media_title' => $this->t('<a href="/media/'.$media->id().'" target="_blank">'.$media->getName().'</a>'),
-                            'groups' => $groups,
-                            'media_permission' => $this->t('<a href="/media/'.$media->id().'/access-control" target="_blank">Configuration</a>'),
-                        ];
-                    }
-                    else {
-                        //$options_available_media[$media->id()] = $media->getName() . "  <a href='/media/".$media->id()."/access-control' target='_blank'>Configure seperately</a>";
-                        $options_available_media[$media->id()] = [
-                            'media_title' => $this->t('<a href="/media/'.$media->id().'" target="_blank">'.$media->getName().'</a>'),
-                            'groups' => $groups,
-                            'media_permission' => $this->t('<a href="/media/'.$media->id().'/access-control" target="_blank">Configuration</a>'),
-                        ];
-                    }
-                }
-            }
-
+          $child_medias = array_merge($child_medias, $other_medias);
         }
 
-        $access_control_field = Utilities::getAccessControlFieldinNode($node);
-        $group_terms = Utilities::getIslandoraAccessTermsinTable();//Utilities::getIslandoraAccessTerms();
-        $node_term_default = [];
-
-        $node_terms = $node->get($access_control_field)->referencedEntities();
-        if (!empty($node_terms)) {
-            // no term, exist
-            foreach ($node_terms as $nt) {
-                if (in_array($nt->id(), array_keys($group_terms))) {
-                    $node_term_default[$nt->id()] = TRUE;
-                }
-                else {
-                    $node_term_default[$nt->id()] = FALSE;
-                }
-            }
+        foreach ($child_medias as $child_media) {
+          $operations[] = ['\Drupal\islandora_group\Utilities::taggingFieldAccessTermMedia', [$child_media, $targets]];
         }
-        $form = [];
-        $form['#title'] = t($node->getTitle() . ' Repository Item Access Control');
-        $form['#tree'] = true;
-
-        $form['nid'] = [
-            '#type' => 'hidden',
-            '#value' => $node->id()
-        ];
-        $form['access-control'] = [
-            '#type' => 'container'
-        ];
-        $form['access-control']['node'] = [
-            '#type' => 'details',
-            '#title' => $this->t($node->getTitle()),
-            '#open' => TRUE,
-        ];
-
-        $header = [
-            'group_name' => $this->t('Group'),
-            'group_permission' => $this->t('Group Permission'),
-            'group_member' => $this->t('Accounts can access'),
-        ];
-
-        $form['access-control']['node']['access-control'] = array(
-            '#id' => 'group-node-table',
-            '#attributes' => array('class' => array('stripe')),
-            '#type' => 'tableselect',
-            '#header' => $header,
-            '#options' => $group_terms,
-            '#default_value' => $node_term_default,
-            '#empty' => $this->t('No users found'),
-            '#prefix' => $this->t('<p><h3>Select which group(s) to add this node to:</h3></p><div class="group-table">'),
-            '#suffix' => $this->t("</div>")
-        );
-
-        $form['access-control']['media'] = [
-            '#type' => 'details',
-            '#title' => $this->t("Media"),
-            '#open' => TRUE,
-        ];
-
-        $header = [
-            'media_title' => $this->t('Media'),
-            'groups' => $this->t("In Group(s)"),
-            'media_permission' => $this->t('Access Control'),
-        ];
-        if (count($options_available_media) > 0) {
-            $form['access-control']['media']['access-control'] = [
-                '#id' => 'group-media-has-access-control-table',
-                '#attributes' => array('class' => array('stripe')),
-                '#type' => 'tableselect',
-                '#title' => $this->t('Select media to add to the above group(s)'),
-                '#options' => $options_available_media,
-                '#header' => $header,
-                '#prefix' => $this->t('<p><h3>Select media to add to the above group(s):</h3></p>
-                                <div class="group-table">'),
-                '#suffix' => $this->t("</div>")
-            ];
-        }
-
-        if (count($options_unvailable_media) > 0) {
-            $form['access-control']['media']['not-access-control'] = [
-                '#id' => 'group-media-has-no-access-control-table',
-                '#attributes' => array('class' => array('stripe')),
-                '#type' => 'table',
-                '#title' => $this->t('The following media already has access control: '),
-                '#rows' => $options_unvailable_media,
-                '#default_value' => array_keys($options_unvailable_media),
-                '#disabled' => true,
-                '#header' => $header,
-                '#prefix' => $this->t('<p><h3>The following already have access control, please review before override them:</h3></p>
-                                <div class="group-table">'),
-                '#suffix' => $this->t("</div>")
-            ];
-            $form['access-control']['media']['<strong>Override</strong>'] = array(
-                '#type' => 'checkbox',
-                '#title' => $this->t('<strong>Override</strong>'),
-                '#description' => $this->t("To have the same access control with this node")
-            );
-        }
-
-        // get children nodes by field_part_of
-        $part_of_NIDs = [];
-        if (entityTypeHasField("node", "field_part_of")) { 
-            $query = \Drupal::entityQuery('node')
-                ->condition('status', 1)
-                ->accessCheck(TRUE)
-                ->condition('field_part_of', $node->id());
-            $part_of_NIDs = $query->execute();
-        }
-        
-
-        if (Utilities::isCollection($node) || count($part_of_NIDs) > 0) {
-            // check if this node is collection, redirect to confirm form
-            // get children nodes
-            // get children nodes by field_member_of
-            $member_of_NIDs= [];
-            $query = \Drupal::entityQuery('node')
-                ->condition('status', 1)
-                ->accessCheck(TRUE)
-                ->condition('field_member_of', $node->id());
-            $member_of_NIDs = $query->execute();
-
-            // merged them
-            //$childrenNids = array_merge($member_of_NIDs, $part_of_NIDs);
-            $childrenNids = array_merge($member_of_NIDs, $part_of_NIDs);
-
-            $options_available_children = [];
-            $options_unvailable_children = [];
-
-            $options = [];
-
-            foreach ($childrenNids as $cnid) {
-                $childNode = \Drupal::entityTypeManager()->getStorage('node')->load($cnid);
-
-                // get access control field from config
-                $access_control_field = Utilities::getAccessControlFieldinNode($childNode);
-
-                $groups = implode(", ", Utilities::getGroupsByNode($cnid));
-                $childnode_terms = $childNode->get($access_control_field)->referencedEntities();
-                if (count($childnode_terms) > 0) {
-                    //$options_unvailable_children[$cnid] = $childNode->getTitle() . '. <a href="/node/'.$childNode->id().'/access-control" target="_blank">Configure seperately</a>';
-                    $options_unvailable_children[$cnid] = [
-                        'node_title' => $this->t('<a href="/node/'.$childNode->id().'" target="_blank">'.$childNode->getTitle().'</a>'),
-                        'groups' => $groups,
-                        'node_permission' => $this->t('<a href="/node/'.$childNode->id().'/access-control" target="_blank">Configuration</a>'),
-                    ];
-                }
-                else {
-                    //$options_available_children[$cnid] = $childNode->getTitle() . '. <a href="/node/'.$childNode->id().'/access-control" target="_blank">Configure seperately</a>';
-                    $options_available_children[$cnid] = [
-                        'node_title' => $this->t('<a href="/node/'.$childNode->id().'" target="_blank">'.$childNode->getTitle().'</a>'),
-                        'groups' => $groups,
-                        'node_permission' => $this->t('<a href="/node/'.$childNode->id().'/access-control" target="_blank">Configuration</a>'),
-                    ];
-                }
-            }
-            $form['access-control']['children-nodes'] = [
-                '#type' => 'details',
-                '#title' => $this->t("Children Nodes"),
-                '#open' => TRUE,
-            ];
-
-            $header = [
-                'node_title' => $this->t('Children Nodes'),
-                "groups" => $this->t("In Group(s)"),
-                'node_permission' => $this->t('Access Control'),
-            ];
-            if (count($options_available_children) > 0) {
-                $form['access-control']['children-nodes']['access-control'] = array(
-                    '#id' => 'group-children-nodes-has-no-access-control-table',
-                    '#attributes' => array('class' => array('stripe')),
-                    '#type' => 'tableselect',
-                    '#header' => $header,
-                    '#options' => $options_available_children,
-                    '#prefix' => $this->t('<p><h3>Select the following children nodes:</h3></p>
-                                <div class="group-table">'),
-                    '#suffix' => $this->t("</div>")
-                );
-            }
-            if (count($options_unvailable_children) > 0) {
-                $form['access-control']['children-nodes']['not-access-control'] = array(
-                    '#id' => 'group-children-nodes-has-access-control-table',
-                    '#attributes' => array('class' => array('stripe')),
-                    '#type' => 'table',
-                    '#header' => $header,
-                    '#rows' => $options_unvailable_children,
-                    '#prefix' => $this->t('<p><h3>The following already have access control, please review before override them:</h3></p>
-                                <div class="group-table">'),
-                    '#suffix' => $this->t("</div>"),
-                    '#default_value' => array_keys($options_unvailable_children),
-                    '#disabled' => true,
-                );
-                $form['access-control']['children-nodes']['<strong>Override</strong>'] = array(
-                    '#type' => 'checkbox',
-                    '#title' => $this->t('<strong>Override</strong>'),
-                    '#description' => $this->t("To have the same access control with this node")
-                );
-            }
-        }
-
-
-
-
-
-        $form['submit'] = array(
-            '#type' => 'submit',
-            '#value' => 'Apply',
-        );
-
-        return $form;
+      }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function submitForm(array &$form, FormStateInterface $form_state)
-    {
-        // get selected group
-        $selected_groups = array_values(array_filter($form_state->getValues()['access-control']['node']['access-control']));
+    // For override children nodes.
+    if (isset($form_state->getValues()['access-control']['children-nodes']['<strong>Override</strong>']) && $form_state->getValues()['access-control']['children-nodes']['<strong>Override</strong>'] == TRUE) {
+      // Override the access control for already set media.
+      $override_childnodes = array_values(array_filter($form_state->getValues()['access-control']['children-nodes']['not-access-control']));
+      foreach ($override_childnodes as $cnid) {
+        // Get selected child node.
+        $child = Node::load($cnid);
 
-        // set selected term id
-        $targets = [];
-        foreach ($selected_groups as $term_id) {
-            $targets[] = ['target_id' => $term_id];
+        // Tagging the child node.
+        $operations[] = ['\Drupal\islandora_group\Utilities::taggingFieldAccessTermsNode', [$cnid, $targets]];
+
+        $child_medias = [];
+        if (!empty(\Drupal::hasService('islandora.utils'))) {
+          $child_medias = \Drupal::service('islandora.utils')->getMedia($child);
         }
-
-        // tagging the parent node level
-        $operations = array(
-            array('\Drupal\islandora_group\Utilities::taggingFieldAccessTermsNode', array($form_state->getValues()['nid'], $targets)),
-        );
-
-        // get selected media
-        if (isset($form_state->getValues()['access-control']['media']['access-control'])) {
-          $selected_media = array_values(array_filter($form_state->getValues()['access-control']['media']['access-control']));
-          foreach ($selected_media as $media_id) {
-              $media = Media::load($media_id);
-
-              // tag the selected media of the node
-              $operations[] = array('\Drupal\islandora_group\Utilities::taggingFieldAccessTermMedia', array($media, $targets));
-          }
+        $other_medias = Utilities::getMedia($child);
+        if (count($other_medias) > 0) {
+          $child_medias = array_merge($child_medias, $other_medias);
         }
-
-
-        // handle override
-        if (isset($form_state->getValues()['access-control']['media']['<strong>Override</strong>']) && $form_state->getValues()['access-control']['media']['<strong>Override</strong>'] == true) {
-            // Override the access control for already set media
-            $override_media = array_values(array_filter($form_state->getValues()['access-control']['media']['not-access-control']));
-            foreach ($override_media as $omid) {
-                $media = Media::load($omid);
-                // tag the override media
-                $operations[] = array('\Drupal\islandora_group\Utilities::taggingFieldAccessTermMedia', array($media, $targets));
-            }
+        foreach ($child_medias as $child_media) {
+          $operations[] = ['\Drupal\islandora_group\Utilities::taggingFieldAccessTermMedia', [$child_media, $targets]];
         }
-
-        // for children node
-        if (isset($form_state->getValues()['access-control']['children-nodes']['access-control'])) {
-          $children_nodes = array_values(array_filter($form_state->getValues()['access-control']['children-nodes']['access-control']));
-          foreach ($children_nodes as $cnid) {
-              // get selected child node
-              $child = Node::load($cnid);
-
-              // tagging the child node
-              $operations[] = array('\Drupal\islandora_group\Utilities::taggingFieldAccessTermsNode', array($cnid, $targets));
-
-              // TODO : UI configure add child's media to group
-              $child_medias = [];
-              if (!empty(\Drupal::hasService('islandora.utils'))) {
-                  $child_medias = \Drupal::service('islandora.utils')->getMedia($child);
-              }
-              $other_medias = Utilities::getMedia($child);
-              if (count($other_medias) > 0) {
-                  $child_medias = array_merge($child_medias, $other_medias);
-              }
-
-              foreach ($child_medias as $child_media) {
-                  $operations[] = array('\Drupal\islandora_group\Utilities::taggingFieldAccessTermMedia', array($child_media, $targets));
-              }
-          }
-        }
-
-        // for override children nodes
-        if (isset($form_state->getValues()['access-control']['children-nodes']['<strong>Override</strong>']) && $form_state->getValues()['access-control']['children-nodes']['<strong>Override</strong>'] == true) {
-            // Override the access control for already set media
-            $override_childnodes = array_values(array_filter($form_state->getValues()['access-control']['children-nodes']['not-access-control']));
-            foreach ($override_childnodes as $cnid) {
-                // get selected child node
-                $child = Node::load($cnid);
-
-                // tagging the child node
-                $operations[] = array('\Drupal\islandora_group\Utilities::taggingFieldAccessTermsNode', array($cnid, $targets));
-
-                $child_medias = [];
-                if (!empty(\Drupal::hasService('islandora.utils'))) {
-                    $child_medias = \Drupal::service('islandora.utils')->getMedia($child);
-                }
-                $other_medias = Utilities::getMedia($child);
-                if (count($other_medias) > 0) {
-                    $child_medias = array_merge($child_medias, $other_medias);
-                }
-                foreach ($child_medias as $child_media) {
-                    $operations[] = array('\Drupal\islandora_group\Utilities::taggingFieldAccessTermMedia', array($child_media, $targets));
-                }
-            }
-        }
-
-        $batch = array(
-            'title' => t('Applying access control...'),
-            'operations' => $operations,
-            'finished' => 'islandora_group_batch_finished',
-            'progress_message' => $this->t('Applied @percentage%'),
-            'error_message' => $this->t('Access control has encountered an error.'),
-        );
-        batch_set($batch);
+      }
     }
+
+    $batch = [
+      'title' => t('Applying access control...'),
+      'operations' => $operations,
+      'finished' => 'islandora_group_batch_finished',
+      'progress_message' => $this->t('Applied @percentage%'),
+      'error_message' => $this->t('Access control has encountered an error.'),
+    ];
+    batch_set($batch);
+  }
+
 }

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -1,10 +1,13 @@
 <?php
 
+// phpcs:disable Drupal.Commenting.FileComment.NamespaceNoFileDoc
+// @todo Re-enable and fix Drupal Coding Standards completely when refactoring.
+// phpcs:disable
+
 namespace Drupal\islandora_group;
 
+use Drupal\node\Entity\Node;
 use Drupal\Core\Entity\EntityForm;
-use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\facets\Exception\Exception;
 use Drupal\node\NodeInterface;
 use Drupal\group\Entity\GroupRelationship;
 use Drupal\media\MediaInterface;
@@ -15,14 +18,13 @@ use Drupal\media\Entity\Media;
 /**
  * Helper functions.
  */
-class Utilities
-{
+class Utilities {
 
   const CONFIG_NAME = 'islandora_group.config';
   const CONFIG_TAXONOMY_VOCAL = 'islandora_group.taxonomy.vocabulary';
 
   /**
-   * @param NodeInterface $node
+   * @param \Drupal\node\NodeInterface $node
    * @return void
    */
   public static function getMedia(NodeInterface $node) {
@@ -46,52 +48,55 @@ class Utilities
   }
 
   /**
-   * Clear out existing Group-entity relations
+   * Clear out existing Group-entity relations.
    *
    * @param $entity
+   *
    * @return void
+   *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public static function clear_group_relation_by_entity($entity) {
-    // get access control field from config
+    // Get access control field from config.
     if ($entity->getEntityTypeId() === "node") {
-      // get access control field from config
+      // Get access control field from config.
       $access_control_field = self::getAccessControlFieldinNode($entity);
-    } else if ($entity->getEntityTypeId() === "media") {
+    }
+    elseif ($entity->getEntityTypeId() === "media") {
       $access_control_field = self::getAccessControlFieldinMedia($entity);
     }
 
-    // check if $access_control_field exists and valid
+    // Check if $access_control_field exists and valid.
     if (empty($access_control_field) || !$entity->hasField($access_control_field)) {
       return;
     }
-    // for each term, loop through groups-entity
+    // For each term, loop through groups-entity.
     foreach (GroupRelationship::loadByEntity($entity) as $group_content) {
       $group_content->delete();
     }
   }
 
-
   /**
-   * @param NodeInterface $node
+   * @param \Drupal\node\NodeInterface $node
+   *
    * @return mixed
    */
   public static function getAccessControlFieldinNode(NodeInterface $node) {
     $config = \Drupal::config(self::CONFIG_NAME);
     $fields = $config->get("node-type-access-fields");
-    return (isset($fields) && array_key_exists($node->bundle(), $fields)) ? $fields[$node->bundle()] : null;
+    return (isset($fields) && array_key_exists($node->bundle(), $fields)) ? $fields[$node->bundle()] : NULL;
   }
 
   /**
-   * @param MediaInterface $media
+   * @param \Drupal\media\MediaInterface $media
+   *
    * @return mixed
    */
   public static function getAccessControlFieldinMedia(MediaInterface $media) {
     $config = \Drupal::config(self::CONFIG_NAME);
     $fields = $config->get("media-type-access-fields");
-    return (isset($fields) && array_key_exists($media->bundle(), $fields)) ? $fields[$media->bundle()] : null;
+    return (isset($fields) && array_key_exists($media->bundle(), $fields)) ? $fields[$media->bundle()] : NULL;
   }
-
 
   /**
    * @param $nid
@@ -100,21 +105,18 @@ class Utilities
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public static function taggingFieldAccessTermsNode($nid, $targets) {
-    // get the node
-    $node = \Drupal\node\Entity\Node::load($nid);
+    // Get the node.
+    $node = Node::load($nid);
 
-    // Clear any previous relations before adding new ones if called from the UI
-
-    // 1. clear field_access_terms in media level
+    // Clear any previous relations before adding new ones if called from the UI.
+    // 1. Clear field_access_terms in media level.
     self::untag_existed_field_access_terms($node);
 
-      // 2. clearing group relation with islandora object
+    // 2. Clearing group relation with islandora object.
     self::clear_group_relation_by_entity($node);
 
-    
-
     if (count($targets) > 0) {
-      // get access control field from config
+      // Get access control field from config.
       $access_control_field = self::getAccessControlFieldinNode($node);
 
       if (!empty($access_control_field)) {
@@ -122,7 +124,7 @@ class Utilities
         $node->save();
       }
     }
-    // add this node to group
+    // Add this node to group.
     self::adding_islandora_object_to_group($node);
   }
 
@@ -136,7 +138,7 @@ class Utilities
     self::untag_existed_field_access_terms($media);
 
     if (count($targets) > 0) {
-      // get access control field from config
+      // Get access control field from config.
       $access_control_field = self::getAccessControlFieldinMedia($media);
       if (!empty($access_control_field) && $media->hasField($access_control_field)) {
         $media->set($access_control_field, $targets);
@@ -146,16 +148,16 @@ class Utilities
     self::adding_media_only_into_group($media);
   }
 
-
-
   /**
-   * Get Islandora Access terms associated with Groups
+   * Get Islandora Access terms associated with Groups.
+   *
    * @return array
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public static function getIslandoraAccessTerms() {
-    // create the taxonomy term which has the same name as Group Name
+    // Create the taxonomy term which has the same name as Group Name.
     $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree("islandora_access");
     $groups = self::arrange_group_by_name();
 
@@ -170,13 +172,15 @@ class Utilities
   }
 
   /**
-   * Get Islandora Access terms associated with Groups
+   * Get Islandora Access terms associated with Groups.
+   *
    * @return array
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public static function getIslandoraAccessTermsinTable() {
-    // create the taxonomy term which has the same name as Group Name
+    // Create the taxonomy term which has the same name as Group Name.
     $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree("islandora_access");
     $groups = self::arrange_group_by_name();
     $group_members = self::getGroupMembers();
@@ -195,9 +199,12 @@ class Utilities
   }
 
   /**
-   * Create a taxonomy term which is the same name with Group
+   * Create a taxonomy term which is the same name with Group.
+   *
    * @param \Drupal\Core\Entity\EntityInterface $entity
+   *
    * @return void
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    * @throws \Drupal\Core\Entity\EntityStorageException
@@ -208,14 +215,14 @@ class Utilities
     }
     $group_type = $entity->bundle();
 
-    // get the Group associated taxonomy vocabulary
+    // Get the Group associated taxonomy vocabulary.
     $config = \Drupal::config(self::CONFIG_NAME);
     $taxonomy = $config->get($group_type);
 
     $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree($taxonomy);
 
-    // create an taxonomy term which has the same name as group name.
-    $existedTerm = null;
+    // Create an taxonomy term which has the same name as group name.
+    $existedTerm = NULL;
     foreach ($terms as $term) {
       if ($term->name === $entity->label()) {
         $existedTerm = $term;
@@ -225,29 +232,25 @@ class Utilities
     switch ($action) {
       case "insert":
       case "update":
-      {
-        // if no found terms, create new one
-        if ($existedTerm == null) {
-          \Drupal\taxonomy\Entity\Term::create([
+        // If no found terms, create new one.
+        if ($existedTerm == NULL) {
+          Term::create([
             'name' => $entity->label(),
             'vid' => $taxonomy,
           ])->save();
         }
         break;
-      }
+
       case "delete":
-      {
-        if ($existedTerm != null) {
+        if ($existedTerm != NULL) {
           $controller = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
           $tobedeleted = $controller->loadMultiple([$existedTerm->tid]);
           $controller->delete($tobedeleted);
         }
         break;
-      }
+
       default:
-      {
         break;
-      }
     }
   }
 
@@ -257,30 +260,33 @@ class Utilities
    */
   public static function isCollection($node) {
     if ($node->hasField('field_model')) {
-      // Get associated term model
+      // Get associated term model.
       $term_id = $node->get("field_model")->getValue()[0]['target_id'];
       $term_name = Term::load($term_id)->get('name')->value;
 
-      // if collection, redirect to the Confirm form with selecting children to tag
+      // If collection, redirect to the Confirm form with selecting children to tag.
       if ($term_name === "Collection") {
-        return true;
+        return TRUE;
 
       }
     }
-    return false;
+    return FALSE;
   }
 
   /**
-   * Adding nodes to group
+   * Adding nodes to group.
+   *
    * @param $entity
+   *
    * @return void
+   *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public static function adding_islandora_object_to_group($entity) {
-    // get access control field from config
+    // Get access control field from config.
     $access_control_field = self::getAccessControlFieldinNode($entity);
 
-    // Exit early if it has no access terms
+    // Exit early if it has no access terms.
     if (empty($access_control_field) || !$entity->hasField($access_control_field)) {
       return;
     }
@@ -288,14 +294,14 @@ class Utilities
     // Get the access terms for the node.
     $node_terms = $entity->get($access_control_field)->referencedEntities();
     if (empty($node_terms)) {
-      // no term, exist
+      // No term, exist.
       return;
     }
 
     // Arrange groups keyed by their name so we can look them up later.
     $groups_by_name = self::arrange_group_by_name();
 
-    // if there is terms in field_access_term
+    // If there is terms in field_access_term.
     foreach ($node_terms as $term) {
       if (isset($groups_by_name[$term->label()])) {
         $group = $groups_by_name[$term->label()];
@@ -304,30 +310,32 @@ class Utilities
     }
   }
 
-
+  /**
+   *
+   */
   public static function updating_islandora_object_to_group($entity) {
-    // get access control field from config
+    // Get access control field from config.
     $access_control_field = self::getAccessControlFieldinNode($entity);
 
-    // Exit early if it has no access terms
+    // Exit early if it has no access terms.
     if (empty($access_control_field) || !$entity->hasField($access_control_field)) {
       return;
     }
 
-    // clear out group relations with islandora_object first
+    // Clear out group relations with islandora_object first.
     self::clear_group_relation_by_entity($entity);
 
     // Get the access terms for the node.
     $node_terms = $entity->get($access_control_field)->referencedEntities();
     if (empty($node_terms)) {
-      // no term, exist
+      // No term, exist.
       return;
     }
 
     // Arrange groups keyed by their name so we can look them up later.
     $groups_by_name = self::arrange_group_by_name();
 
-    // if there is terms in field_access_term
+    // If there is terms in field_access_term.
     foreach ($node_terms as $term) {
       if (isset($groups_by_name[$term->label()])) {
         $group = $groups_by_name[$term->label()];
@@ -336,29 +344,30 @@ class Utilities
     }
   }
 
-
   /**
-   * Tag a media in to Group
-   * @param MediaInterface $media
+   * Tag a media in to Group.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *
    * @return void
    */
   public static function adding_media_of_islandora_object_to_group($node, $media) {
-    // For media is no parted of any islandora_object
+    // For media is no parted of any islandora_object.
     if (empty($node)) {
 
-      // clear group relation from media
+      // Clear group relation from media.
       self::clear_group_relation_by_entity($media);
 
-      // add media to node
+      // Add media to node.
       self::adding_media_only_into_group($media);
 
       return;
     }
 
-    // get access control field from config
+    // Get access control field from config.
     $access_control_field = self::getAccessControlFieldinNode($node);
 
-    // For media is parted of an islandora_object
+    // For media is parted of an islandora_object.
     if (empty($access_control_field) || !$node->hasField($access_control_field)) {
       return;
     }
@@ -366,17 +375,17 @@ class Utilities
     // Arrange groups keyed by their name so we can look them up later.
     $groups_by_name = self::arrange_group_by_name();
 
-    // clear group relations with the media first
+    // Clear group relations with the media first.
     self::clear_group_relation_by_entity($media);
 
     // Get the access terms for the node.
     $terms = $node->get($access_control_field)->referencedEntities();
     if (empty($terms)) {
-      // no term, exit;
+      // No term, exit;.
       return;
     }
 
-    // get access control field from config
+    // Get access control field from config.
     $access_control_field = self::getAccessControlFieldinMedia($media);
 
     if (empty($access_control_field) || !$media->hasField($access_control_field)) {
@@ -384,13 +393,13 @@ class Utilities
     }
     $media->set($access_control_field, []);
 
-    // if there is terms, loop through and add media group
+    // If there is terms, loop through and add media group.
     foreach ($terms as $term) {
       if (isset($groups_by_name[$term->label()])) {
         $group = $groups_by_name[$term->label()];
         $group->addRelationship($media, 'group_media:' . $media->bundle());
 
-        // tag field_access_term in media
+        // Tag field_access_term in media.
         $media->field_access_terms[] = ['target_id' => $term->id()];
         $media->save();
       }
@@ -399,14 +408,16 @@ class Utilities
 
   /**
    * Remove term(s) in field_access_terms.
+   *
    * @param $ne
+   *
    * @return void
    */
   public static function clear_term_in_field_access_terms($ne, $group_name) {
-    // get access control field from config
+    // Get access control field from config.
     $access_control_field = self::getAccessControlFieldinNode($ne);
 
-    // TODO: search if the node->field_access_terms contain group name
+    // @todo search if the node->field_access_terms contain group name
     if (empty($access_control_field) || !$ne->hasField($access_control_field)) {
       return;
     }
@@ -430,13 +441,14 @@ class Utilities
    */
   public static function untag_existed_field_access_terms($entity) {
     if ($entity->getEntityTypeId() === "node") {
-      // get access control field from config
+      // Get access control field from config.
       $access_control_field = self::getAccessControlFieldinNode($entity);
-    } else if ($entity->getEntityTypeId() === "media") {
+    }
+    elseif ($entity->getEntityTypeId() === "media") {
       $access_control_field = self::getAccessControlFieldinMedia($entity);
     }
 
-    // check if $access_control_field exists and valid
+    // Check if $access_control_field exists and valid.
     if (empty($access_control_field) || !$entity->hasField($access_control_field)) {
       return;
     }
@@ -448,6 +460,9 @@ class Utilities
     }
   }
 
+  /**
+   *
+   */
   public static function getGroupMembers() {
     // Arrange groups keyed by their name so we can look them up later.
     $groups = \Drupal::service('entity_type.manager')->getStorage('group')->loadMultiple();
@@ -465,23 +480,25 @@ class Utilities
   }
 
   /**
-   * Tag a media in to Group
-   * @param MediaInterface $media
+   * Tag a media in to Group.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *
    * @return void
    */
   public static function adding_media_only_into_group(MediaInterface $media) {
-    // get access control field from config
+    // gGet access control field from config.
     $access_control_field = self::getAccessControlFieldinMedia($media);
 
-    // For standalone media (no parent node)
+    // For standalone media (no parent node).
     if (empty($access_control_field) || !$media->hasField($access_control_field)) {
       return;
     }
 
-    // get field_access_terms
+    // Get field_access_terms.
     $terms = $media->get($access_control_field)->referencedEntities();
     if (empty($terms)) {
-      // no term, exit;
+      // No term, exit;.
       return;
     }
 
@@ -495,57 +512,58 @@ class Utilities
       }
     }
   }
-
-
-  public static function updating_media_only_into_group(MediaInterface $media) {
-    // get access control field from config
-    $access_control_field = self::getAccessControlFieldinMedia($media);
-
-    // For standalone media (no parent node)
-    if (empty($access_control_field) || !$media->hasField($access_control_field)) {
-      return;
-    }
-
-    // clear group relation with media
-    self::clear_group_relation_by_entity($media);
-
-    // get field_access_terms
-    $terms = $media->get($access_control_field)->referencedEntities();
-    if (empty($terms)) {
-      // no term, exit;
-      return;
-    }
-
-    // Arrange groups keyed by their name so we can look them up later.
-    $groups_by_name = self::arrange_group_by_name();
-
-    foreach ($terms as $term) {
-      if (isset($groups_by_name[$term->label()])) {
-        $group = $groups_by_name[$term->label()];
-        $group->addRelationship($media, 'group_media:' . $media->bundle());
-      }
-    }
-  }
-
-
-
 
   /**
-   * Redirect to confirm form to add Children nodes to groups
+   *
+   */
+  public static function updating_media_only_into_group(MediaInterface $media) {
+    // Get access control field from config.
+    $access_control_field = self::getAccessControlFieldinMedia($media);
+
+    // For standalone media (no parent node).
+    if (empty($access_control_field) || !$media->hasField($access_control_field)) {
+      return;
+    }
+
+    // Clear group relation with media.
+    self::clear_group_relation_by_entity($media);
+
+    // Get field_access_terms.
+    $terms = $media->get($access_control_field)->referencedEntities();
+    if (empty($terms)) {
+      // No term, exit;.
+      return;
+    }
+
+    // Arrange groups keyed by their name so we can look them up later.
+    $groups_by_name = self::arrange_group_by_name();
+
+    foreach ($terms as $term) {
+      if (isset($groups_by_name[$term->label()])) {
+        $group = $groups_by_name[$term->label()];
+        $group->addRelationship($media, 'group_media:' . $media->bundle());
+      }
+    }
+  }
+
+  /**
+   * Redirect to confirm form to add Children nodes to groups.
+   *
    * @param $form
    * @param $form_state
    * @param $entity
+   *
    * @return void
    */
   public static function redirect_adding_childrennode_to_group($form, $form_state, $entity) {
     if ($entity->hasField('field_model')) {
-      // Get associated term model
+      // Get associated term model.
       $term_id = $entity->get("field_model")->getValue()[0]['target_id'];
       $term_name = Term::load($term_id)->get('name')->value;
 
-      // if collection, redirect to the Confirm form with selecting children to tag
+      // If collection, redirect to the Confirm form with selecting children to tag.
       if ($term_name === "Collection") {
-        // check if this node is collection, redirect to confirm form
+        // Check if this node is collection, redirect to confirm form.
         $form_state->setRedirect('islandora_group.recursive_apply_accesscontrol', [
           'nid' => $entity->id(),
         ]);
@@ -553,9 +571,9 @@ class Utilities
     }
   }
 
-
   /**
-   * Return arranged array of Groups with names
+   * Return arranged array of Groups with names.
+   *
    * @return array
    */
   public static function arrange_group_by_name(): array {
@@ -628,58 +646,67 @@ class Utilities
   }
 
   /**
-   * Custom function form_alter
+   * Custom function form_alter.
+   *
    * @return void
    */
   public function cus_form_alter() {
     if ($form_id === "node_islandora_object_edit_form") {
-      // when update node form
+      // When update node form.
       $form['actions']['submit']['#submit'][] = 'form_submit_update_tagging_node_to_group';
-    } else if ($form_id === "node_islandora_object_form") {
-      // when insert node form
+    }
+    elseif ($form_id === "node_islandora_object_form") {
+      // When insert node form.
       $form['actions']['submit']['#submit'][] = 'form_submit_insert_tagging_node_to_group';
-    } else if (str_starts_with($form_id, "media_") && str_ends_with($form_id, "_edit_form")) {
-      // when update media form
+    }
+    elseif (str_starts_with($form_id, "media_") && str_ends_with($form_id, "_edit_form")) {
+      // When update media form.
       $form['actions']['submit']['#submit'][] = 'form_submit_update_tagging_media_to_group';
-    } else if (str_starts_with($form_id, "media_") && str_ends_with($form_id, "_add_form")) {
-      // when insert update
+    }
+    elseif (str_starts_with($form_id, "media_") && str_ends_with($form_id, "_add_form")) {
+      // When insert update.
       $form['actions']['submit']['#submit'][] = 'form_submit_insert_tagging_media_to_group';
     }
   }
 
   /**
-   * Form submit insert tagging media to group at /media/{{id}}/add
+   * Form submit insert tagging media to group at /media/{{id}}/add.
+   *
    * @param $form
    * @param $form_state
+   *
    * @return void
    */
   public static function form_submit_insert_tagging_media_to_group($form, $form_state) {
-    // For media has parent node, but has different acess term set
+    // For media has parent node, but has different acess term set.
     /** @var \Drupal\Core\Entity\EntityForm $form_object */
     $form_object = $form_state->getFormObject();
     if ($form_object instanceof EntityForm) {
       $media = $form_object->getEntity();
 
-      // add media only to group
+      // Add media only to group.
       self::adding_media_only_into_group($media);
     }
   }
 
   /**
-   * Form submit update tagging media to groups at /media/{{id}}/edit
+   * Form submit update tagging media to groups at /media/{{id}}/edit.
+   *
    * @param $form
    * @param $form_state
+   *
    * @return void
+   *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public static function form_submit_update_tagging_media_to_group($form, $form_state) {
-    // For media has parent node, but has different acess term set
+    // For media has parent node, but has different acess term set.
     /** @var \Drupal\Core\Entity\EntityForm $form_object */
     $form_object = $form_state->getFormObject();
     if ($form_object instanceof EntityForm) {
       $media = $form_object->getEntity();
 
-      // add media only to group
+      // Add media only to group.
       self::updating_media_only_into_group($media);
     }
   }
@@ -700,23 +727,25 @@ class Utilities
         if ($entity->getEntity()->getEntityTypeId() === "node") {
           $node = $group_content->getEntity();
 
-          // update field access terms in node level
+          // Update field access terms in node level.
           self::clear_term_in_field_access_terms($node, $group->label());
-        } else if ($entity->getEntity()->getEntityTypeId() === "media") {
+        }
+        elseif ($entity->getEntity()->getEntityTypeId() === "media") {
           $media = $group_content->getEntity();
 
-          // update field access terms in media level
+          // Update field access terms in media level.
           self::clear_term_in_field_access_terms($media, $group->label());
         }
       }
     }
   }
 
-
   /**
-   * Override form submit when tagging node to group when insert at /node/add
+   * Override form submit when tagging node to group when insert at /node/add.
+   *
    * @param $form
    * @param $form_state
+   *
    * @return void
    */
   public static function form_submit_insert_tagging_node_to_group($form, $form_state) {
@@ -724,51 +753,54 @@ class Utilities
     $form_object = $form_state->getFormObject();
     if ($form_object instanceof EntityForm) {
 
-      // get the entity from form
+      // Get the entity from form.
       $entity = $form_object->getEntity();
 
-      // add node to group
+      // Add node to group.
       self::adding_islandora_object_to_group($entity);
     }
   }
 
   /**
-   * Override form submit for edit form at /node/nid/edit
+   * Override form submit for edit form at /node/nid/edit.
+   *
    * @param $form
    * @param $form_state
+   *
    * @return void
+   *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  function form_submit_update_tagging_node_to_group($form, $form_state) {
+  public function form_submit_update_tagging_node_to_group($form, $form_state) {
     /** @var \Drupal\Core\Entity\EntityForm $form_object */
     $form_object = $form_state->getFormObject();
     if ($form_object instanceof EntityForm) {
 
-      // get the entity from form
+      // Get the entity from form.
       $entity = $form_object->getEntity();
 
-      // add node to group
+      // Add node to group.
       self::updating_islandora_object_to_group($entity);
 
-      // redirect if the islandora_object is a collection
+      // Redirect if the islandora_object is a collection.
       self::redirect_adding_childrennode_to_group($form, $form_state, $entity);
     }
 
   }
 
-
   /**
-   * Determine called from Group Module Strage save
+   * Determine called from Group Module Strage save.
+   *
    * @return bool
    */
   public static function isCalledFromGroupModule() {
     $backtrace = debug_backtrace();
-    $redudent = false;
+    $redudent = FALSE;
     while ($frame = next($backtrace)) {
-      if ((isset($frame['class']) && (strpos($frame['class'], 'Drupal\\group') !== false))
+      if ((isset($frame['class']) && (strpos($frame['class'], 'Drupal\\group') !== FALSE))
         || (isset($frame['class']) && $frame['function'] === 'taggingFieldAccessTermsNode')
         || (isset($frame['class']) && $frame['function'] === 'taggingFieldAccessTermMedia')) {
-        $redudent = true;
+        $redudent = TRUE;
         break;
       }
     }
@@ -776,16 +808,17 @@ class Utilities
   }
 
   /**
-   * Determine called from ViewsBulkOperationsActionBase
+   * Determine called from ViewsBulkOperationsActionBase.
+   *
    * @return bool
    */
   public static function isCalledFromBulkBatch() {
     $backtrace = debug_backtrace();
-    $redudent = false;
+    $redudent = FALSE;
     while ($frame = next($backtrace)) {
-      if (isset($frame['class']) === true && $frame['class'] === "Drupal\\views_bulk_operations\\Action\\ViewsBulkOperationsActionBase"
+      if (isset($frame['class']) === TRUE && $frame['class'] === "Drupal\\views_bulk_operations\\Action\\ViewsBulkOperationsActionBase"
         && $frame['function'] === "executeMultiple") {
-        $redudent = true;
+        $redudent = TRUE;
         break;
       }
     }
@@ -797,13 +830,13 @@ class Utilities
    * @return array
    */
   public static function getGroupsByNode($nid) {
-    $group_ids = array();
+    $group_ids = [];
     $ids = \Drupal::entityQuery('group_relationship')
       ->condition('entity_id', $nid)
       ->accessCheck(TRUE)
       ->execute();
 
-    $relations = \Drupal\group\Entity\GroupRelationship::loadMultiple($ids);
+    $relations = GroupRelationship::loadMultiple($ids);
     foreach ($relations as $rel) {
       if ($rel->getEntity()->getEntityTypeId() == 'node') {
         $group_ids[] = $rel->getGroup()->label();
@@ -818,13 +851,13 @@ class Utilities
    * @return array
    */
   public static function getGroupsByMedia($mid) {
-    $group_ids = array();
+    $group_ids = [];
     $ids = \Drupal::entityQuery('group_relationship')
       ->condition('entity_id', $mid)
       ->accessCheck(TRUE)
       ->execute();
 
-    $relations = \Drupal\group\Entity\GroupRelationship::loadMultiple($ids);
+    $relations = GroupRelationship::loadMultiple($ids);
     foreach ($relations as $rel) {
       if ($rel->getEntity()->getEntityTypeId() == 'media') {
         $group_ids[] = $rel->getGroup()->label();
@@ -832,4 +865,5 @@ class Utilities
     }
     return $group_ids;
   }
+
 }

--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -4,12 +4,14 @@ namespace Drupal\Tests\islandora_group\Functional;
 
 use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Simple test to ensure that main page loads with module enabled.
  *
  * @group islandora_group
  */
+#[RunTestsInSeparateProcesses]
 class LoadTest extends BrowserTestBase {
 
   /**
@@ -27,6 +29,12 @@ class LoadTest extends BrowserTestBase {
   protected static $modules = ['islandora_group'];
 
   /**
+   * {@inheritdoc}
+   */
+  // phpcs:ignore -- Do not disable strict config schema checking in tests.
+  protected $strictConfigSchema = FALSE;
+
+  /**
    * A user with permission to administer site configuration.
    *
    * @var \Drupal\user\UserInterface
@@ -36,7 +44,7 @@ class LoadTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->user = $this->drupalCreateUser(['administer site configuration']);
     $this->drupalLogin($this->user);


### PR DESCRIPTION
# Description
This PR lints the codebase, makes minor adjustments to the `LoadTest` functional test to fix PHPUnit errors, and adds missing dependencies in `composer.json` file.

# Changes
- Lint the codebase.
- Add missing dependencies in `composer.json` file.
- Add `#[RunTestsInSeparateProcesses]` to follow the new changes in Drupal ([Reference](https://www.drupal.org/node/3548485)).
- Disable strict config schema checking in tests.
- Update function header to match new coding standards.